### PR TITLE
Phoenix-kmm issue #123: Missing transactions when closing channels

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -561,9 +561,11 @@ data class WaitForInit(override val staticParams: StaticParams, override val cur
                     // In order to allow TLV extensions and keep backwards-compatibility, we include an empty upfront_shutdown_script.
                     // See https://github.com/lightningnetwork/lightning-rfc/pull/714.
                     tlvStream = TlvStream(
-                        listOf(ChannelTlv.UpfrontShutdownScript(ByteVector.empty)) +
-                                if (event.channelVersion.isSet(ChannelVersion.ZERO_RESERVE_BIT)) listOf(ChannelTlv.ChannelVersionTlv(event.channelVersion)) else listOf<ChannelTlv>() +
-                                        if (event.channelOrigin != null) listOf(ChannelTlv.ChannelOriginTlv(event.channelOrigin)) else listOf()
+                        buildList {
+                            add(ChannelTlv.UpfrontShutdownScript(ByteVector.empty))
+                            if (event.channelVersion.isSet(ChannelVersion.ZERO_RESERVE_BIT)) add(ChannelTlv.ChannelVersionTlv(event.channelVersion))
+                            if (event.channelOrigin != null) add(ChannelTlv.ChannelOriginTlv(event.channelOrigin))
+                        }
                     )
                 )
                 val nextState = WaitForAcceptChannel(staticParams, currentTip, currentOnChainFeerates, event, open)

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2608,7 +2608,11 @@ data class Closing(
                             futureRemoteCommitPublished = this.futureRemoteCommitPublished?.update(watch.tx),
                             revokedCommitPublished = this.revokedCommitPublished.map { it.update(watch.tx) }
                         )
-                        closing1.networkFeePaid(watch.tx)?.let { logger.info { "c:$channelId paid fee=${it.first} for txid=${watch.tx.txid} desc=${it.second}" } }
+                        closing1.networkFeePaid(watch.tx)?.let {
+                            logger.info { "c:$channelId paid fee=${it.first} for txid=${watch.tx.txid} desc=${it.second}" }
+                        } ?: run {
+                            logger.info { "c:$channelId paid UNKNOWN fee for txid=${watch.tx.txid}" }
+                        }
 
                         // we may need to fail some htlcs in case a commitment tx was published and they have reached the timeout threshold
                         val htlcSettledActions = mutableListOf<ChannelAction>()

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -781,10 +781,10 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
                                 currentTip,
                                 currentOnChainFeerates,
                                 state.commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(watch.tx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(watch.tx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -1042,10 +1042,10 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 currentTip,
                                 currentOnChainFeerates,
                                 state.commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(watch.tx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(watch.tx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2357,10 +2357,10 @@ data class Negotiating(
                                 currentTip,
                                 currentOnChainFeerates,
                                 commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                this.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(signedClosingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(signedClosingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2378,10 +2378,10 @@ data class Negotiating(
                                 currentTip,
                                 currentOnChainFeerates,
                                 commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
-                                listOf(signedClosingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
+                                mutualClosePublished = listOf(signedClosingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2424,10 +2424,10 @@ data class Negotiating(
                             currentTip,
                             currentOnChainFeerates,
                             commitments,
-                            null,
-                            currentBlockHeight.toLong(),
-                            this.closingTxProposed.flatten().map { it.unsignedTx },
-                            listOf(watch.tx)
+                            fundingTx = null,
+                            waitingSinceBlock = currentBlockHeight.toLong(),
+                            mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx },
+                            mutualClosePublished = listOf(watch.tx)
                         )
                         val actions = listOf(
                             ChannelAction.Storage.StoreState(nextState),
@@ -2464,10 +2464,10 @@ data class Negotiating(
                     currentTip,
                     currentOnChainFeerates,
                     commitments,
-                    null,
-                    currentBlockHeight.toLong(),
-                    this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
-                    listOf(bestUnpublishedClosingTx)
+                    fundingTx = null,
+                    waitingSinceBlock = currentBlockHeight.toLong(),
+                    mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
+                    mutualClosePublished = listOf(bestUnpublishedClosingTx)
                 )
                 val actions = listOf(
                     ChannelAction.Storage.StoreState(nextState),

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
@@ -417,6 +417,6 @@ data class ClosingTxProposed(val unsignedTx: Transaction, val localClosingSigned
 /** This gives the reason for creating a new channel */
 @Serializable
 sealed class ChannelOrigin {
-    data class PayToOpenOrigin(val paymentHash: ByteVector32) : ChannelOrigin()
-    data class SwapInOrigin(val bitcoinAddress: String) : ChannelOrigin()
+    data class PayToOpenOrigin(val paymentHash: ByteVector32, val fee: Satoshi) : ChannelOrigin()
+    data class SwapInOrigin(val bitcoinAddress: String, val fee: Satoshi) : ChannelOrigin()
 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
@@ -417,6 +417,7 @@ data class ClosingTxProposed(val unsignedTx: Transaction, val localClosingSigned
 /** This gives the reason for creating a new channel */
 @Serializable
 sealed class ChannelOrigin {
-    data class PayToOpenOrigin(val paymentHash: ByteVector32, val fee: Satoshi) : ChannelOrigin()
-    data class SwapInOrigin(val bitcoinAddress: String, val fee: Satoshi) : ChannelOrigin()
+    abstract val fee: Satoshi
+    data class PayToOpenOrigin(val paymentHash: ByteVector32, override val fee: Satoshi) : ChannelOrigin()
+    data class SwapInOrigin(val bitcoinAddress: String, override val fee: Satoshi) : ChannelOrigin()
 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
@@ -51,22 +51,25 @@ class InMemoryPaymentsDb : PaymentsDb {
         return outgoing[id]?.let { payment ->
             val parts = outgoingParts.values.filter { it.first == payment.id }.map { it.second }
             return when (payment.status) {
-                is OutgoingPayment.Status.Succeeded -> payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
+                // This doesn't work. Is there something like "instanceof" to check inheritance ???
+            //  is OutgoingPayment.Status.Completed.Succeeded -> {
+            //      payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
+            //  }
+                is OutgoingPayment.Status.Completed.Succeeded.OffChain -> {
+                    payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
+                }
+                is OutgoingPayment.Status.Completed.Succeeded.OnChain -> {
+                    payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
+                }
                 else -> payment.copy(parts = parts)
             }
         }
     }
 
-    override suspend fun updateOutgoingPayment(id: UUID, failure: FinalFailure, completedAt: Long) {
+    override suspend fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed) {
         require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
         val payment = outgoing[id]!!
-        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Failed(failure, completedAt))
-    }
-
-    override suspend fun updateOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long) {
-        require(outgoing.contains(id)) { "outgoing payment with id=$id doesn't exist" }
-        val payment = outgoing[id]!!
-        outgoing[id] = payment.copy(status = OutgoingPayment.Status.Succeeded(preimage, completedAt))
+        outgoing[id] = payment.copy(status = completed)
     }
 
     override suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
@@ -104,7 +107,7 @@ class InMemoryPaymentsDb : PaymentsDb {
     override suspend fun listOutgoingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter>): List<OutgoingPayment> =
         outgoing.values
             .asSequence()
-            .filter { it.details.matchesFilters(filters) && (it.status is OutgoingPayment.Status.Failed || it.status is OutgoingPayment.Status.Succeeded) }
+            .filter { it.details.matchesFilters(filters) && (it.status is OutgoingPayment.Status.Completed) }
             .sortedByDescending { WalletPayment.completedAt(it) }
             .drop(skip)
             .take(count)

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -3,6 +3,7 @@ package fr.acinq.eclair.db
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.channel.ChannelException
@@ -222,7 +223,7 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
             data class Failed(val reason: FinalFailure, override val completedAt: Long = currentTimestampMillis()) : Completed()
             sealed class Succeeded : Completed() {
                 data class OffChain(val preimage: ByteVector32, override val completedAt: Long = currentTimestampMillis()) : Completed()
-                data class OnChain(val txids: List<ByteVector32>, override val completedAt: Long = currentTimestampMillis()) : Completed()
+                data class OnChain(val txids: List<ByteVector32>, val claimed: Satoshi, override val completedAt: Long = currentTimestampMillis()) : Completed()
             }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -168,10 +168,26 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
     constructor(id: UUID, amount: MilliSatoshi, recipient: PublicKey, details: Details) : this(id, amount, recipient, details, listOf(), Status.Pending)
 
     val paymentHash: ByteVector32 = details.paymentHash
-    val fees: MilliSatoshi = when (status) {
-        is Status.Completed.Failed -> 0.msat
-        else -> parts.filter { it.status is Part.Status.Succeeded || it.status == Part.Status.Pending }.map { it.amount }.sum() - recipientAmount
-    }
+    val fees: MilliSatoshi =
+        if (details is Details.Normal) {
+            when (status) {
+                is Status.Completed.Failed -> 0.msat
+                else -> {
+                    val sum = parts.filter {
+                        it.status is Part.Status.Succeeded || it.status == Part.Status.Pending
+                    }.map { it.amount }.sum()
+                    if (sum < recipientAmount && status is Status.Pending) {
+                        // We don't have all the parts yet, so the total fees are unknown.
+                        0.msat
+                    } else {
+                        sum - recipientAmount
+                    }
+                }
+            }
+
+        } else {
+            0.msat
+        }
 
     sealed class Details {
         abstract val paymentHash: ByteVector32

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -164,7 +164,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
  * @param parts partial child payments that have actually been sent.
  * @param status current status of the payment.
  */
-data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val recipient: PublicKey, val details: Details, val parts: List<Part>, val status: Status) : WalletPayment() {
+data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val recipient: PublicKey, val details: Details, val parts: List<Part>, val status: Status, val createdAt: Long = currentTimestampMillis()) : WalletPayment() {
     constructor(id: UUID, amount: MilliSatoshi, recipient: PublicKey, details: Details) : this(id, amount, recipient, details, listOf(), Status.Pending)
 
     val paymentHash: ByteVector32 = details.paymentHash

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -44,19 +44,11 @@ interface OutgoingPaymentsDb {
     /** Mark an outgoing payment as completed (failed, succeeded, mined). */
     suspend fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed)
 
-    suspend fun completeOutgoingPayment(id: UUID, finalFailure: FinalFailure, completedAt: Long? = null) =
-        if (completedAt != null) {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure, completedAt))
-        } else {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure))
-        }
+    suspend fun completeOutgoingPayment(id: UUID, finalFailure: FinalFailure, completedAt: Long = currentTimestampMillis()) =
+        completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure, completedAt))
 
-    suspend fun completeOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long? = null) =
-        if (completedAt != null) {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, completedAt))
-        } else {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage))
-        }
+    suspend fun completeOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis()) =
+        completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, completedAt))
 
     /** Add new partial payments to a pending outgoing payment. */
     suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>)

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -390,7 +390,7 @@ class Peer(
                     db.payments.addOutgoingPayment(payment)
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }
-                action is ChannelAction.Storage.CompleteChannelClosing -> {
+                action is ChannelAction.Storage.StoreChannelClosed -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
                     val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed)
                     db.payments.completeOutgoingPayment(dbId, completed)

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -392,7 +392,7 @@ class Peer(
                 }
                 action is ChannelAction.Storage.CompleteChannelClosing -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
-                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids)
+                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed)
                     db.payments.completeOutgoingPayment(dbId, completed)
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -2,6 +2,7 @@ package fr.acinq.eclair.io
 
 import fr.acinq.bitcoin.*
 import fr.acinq.eclair.*
+import fr.acinq.eclair.Eclair.randomBytes32
 import fr.acinq.eclair.Eclair.randomKeyPath
 import fr.acinq.eclair.blockchain.GetTxWithMeta
 import fr.acinq.eclair.blockchain.WatchEvent
@@ -53,6 +54,7 @@ data class PaymentReceived(val incomingPayment: IncomingPayment, val received: I
 data class PaymentProgress(val request: SendPayment, val fees: MilliSatoshi) : PeerListenerEvent()
 data class PaymentNotSent(val request: SendPayment, val reason: OutgoingPaymentFailure) : PeerListenerEvent()
 data class PaymentSent(val request: SendPayment, val payment: OutgoingPayment) : PeerListenerEvent()
+data class ChannelClosing(val channelId: ByteVector32) : PeerListenerEvent()
 
 object SendSwapInRequest: PeerEvent()
 data class SwapInResponseEvent(val swapInResponse: SwapInResponse): PeerListenerEvent()
@@ -370,6 +372,29 @@ class Peer(
                 action is ChannelAction.Storage.GetHtlcInfos -> {
                     val htlcInfos = db.channels.listHtlcInfos(actualChannelId, action.commitmentNumber).map { ChannelAction.Storage.HtlcInfo(actualChannelId, action.commitmentNumber, it.first, it.second) }
                     input.send(WrappedChannelEvent(actualChannelId, ChannelEvent.GetHtlcInfosResponse(action.revokedCommitTxId, htlcInfos)))
+                }
+                action is ChannelAction.Storage.StoreChannelClosing -> {
+                    val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
+                    val payment = OutgoingPayment(
+                        id = dbId,
+                        recipientAmount = action.amount,
+                        recipient = PublicKey.Generator,
+                        details = OutgoingPayment.Details.ChannelClosing(
+                            closingAddress = action.closingAddress,
+                            isLocalWallet = action.isLocalWallet,
+                            paymentHash = randomBytes32()
+                        ),
+                        parts = listOf<OutgoingPayment.Part>(),
+                        status = OutgoingPayment.Status.Pending
+                    )
+                    db.payments.addOutgoingPayment(payment)
+                    listenerEventChannel.send(ChannelClosing(channelId))
+                }
+                action is ChannelAction.Storage.CompleteChannelClosing -> {
+                    val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
+                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids)
+                    db.payments.completeOutgoingPayment(dbId, completed)
+                    listenerEventChannel.send(ChannelClosing(channelId))
                 }
                 action is ChannelAction.ChannelId.IdSwitch -> {
                     logger.info { "n:$remoteNodeId c:$actualChannelId switching channel id from ${action.oldChannelId} to ${action.newChannelId}" }

--- a/src/commonMain/kotlin/fr/acinq/eclair/utils/UUID.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/utils/UUID.kt
@@ -90,6 +90,11 @@ class UUID(val mostSignificantBits: Long, val leastSignificantBits: Long) : Comp
 
         fun randomUUID(): UUID {
             val data = ByteArray(16).also { Random.secure().nextBytes(it) }
+            return fromBytes(data)
+        }
+
+        fun fromBytes(data: ByteArray): UUID {
+            require(data.size == 16) { "data must be exactly 16 bytes" }
             data[6] = (data[6].toInt() and 0x0F).toByte()
             data[6] = (data[6].toInt() or 0x40).toByte()
             data[8] = (data[8].toInt() and 0x3F).toByte()

--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
@@ -1084,6 +1084,7 @@ object UnsetFCMToken : LightningMessage {
 
     override fun write(out: Output) {}
 }
+
 @OptIn(ExperimentalUnsignedTypes::class)
 data class SwapInRequest(
     override val chainHash: ByteVector32

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/TestsHelper.kt
@@ -66,7 +66,8 @@ object TestsHelper {
         channelVersion: ChannelVersion = ChannelVersion.STANDARD,
         currentHeight: Int = TestConstants.defaultBlockHeight,
         fundingAmount: Satoshi = TestConstants.fundingAmount,
-        pushMsat: MilliSatoshi = TestConstants.pushMsat
+        pushMsat: MilliSatoshi = TestConstants.pushMsat,
+        channelOrigin: ChannelOrigin? = null
     ): Triple<WaitForAcceptChannel, WaitForOpenChannel, OpenChannel> {
         var alice: ChannelState = WaitForInit(
             StaticParams(TestConstants.Alice.nodeParams, TestConstants.Bob.keyManager.nodeId),
@@ -96,7 +97,8 @@ object TestsHelper {
                 aliceChannelParams,
                 bobInit,
                 channelFlags,
-                channelVersion
+                channelVersion,
+                channelOrigin
             )
         )
         alice = ra.first

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -1547,7 +1547,7 @@ class ClosingTestsCommon : EclairTestSuite() {
                 val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(alice1 is Closing)
                 assertEquals(7, actions1.size)
-                assertTrue(actions1.contains(ChannelAction.Storage.PaymentSent(alice1.commitments.localCommit.spec.toLocal)))
+                assertTrue(actions1.contains(ChannelAction.Storage.StoreOutgoingAmount(alice1.commitments.localCommit.spec.toLocal)))
 
                 val error = actions1.hasOutgoingMessage<Error>()
                 assertEquals(ForcedLocalCommit(alice.channelId).message, error.toAscii())
@@ -1574,7 +1574,7 @@ class ClosingTestsCommon : EclairTestSuite() {
                 val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(bob1 is Closing)
                 assertEquals(7, actions1.size)
-                assertTrue(actions1.contains(ChannelAction.Storage.PaymentSent(bob1.commitments.localCommit.spec.toLocal)))
+                assertTrue(actions1.contains(ChannelAction.Storage.StoreOutgoingAmount(bob1.commitments.localCommit.spec.toLocal)))
 
                 val error = actions1.hasOutgoingMessage<Error>()
                 assertEquals(ForcedLocalCommit(alice.channelId).message, error.toAscii())

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -457,7 +457,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         val (aliceClosed, actions) = alice.processEx(ChannelEvent.WatchReceived(watchConfirmed.last()))
         assertTrue(aliceClosed is Closed)
         assertTrue(actions.contains(ChannelAction.Storage.StoreState(aliceClosed)))
-        assertNotNull(actions.filterIsInstance<ChannelAction.Storage.CompleteChannelClosing>().firstOrNull())
+        assertNotNull(actions.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull())
         // We notify the payment handler that the non-dust htlc has been failed.
         val htlcFail = actions.filterIsInstance<ChannelAction.ProcessCmdRes.AddSettledFail>().first()
         assertEquals(htlcs[0], htlcFail.htlc)
@@ -913,7 +913,7 @@ class ClosingTestsCommon : EclairTestSuite() {
             listOf(ChannelAction.Storage.StoreState(alice5)),
             aliceActions5.filterIsInstance<ChannelAction.Storage.StoreState>()
         )
-        assertEquals(1, aliceActions5.filterIsInstance<ChannelAction.Storage.CompleteChannelClosing>().size)
+        assertEquals(1, aliceActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().size)
     }
 
     @Test
@@ -1549,7 +1549,7 @@ class ClosingTestsCommon : EclairTestSuite() {
                 when (action) {
                     is ChannelAction.ProcessCmdRes -> true
                     is ChannelAction.Storage.StoreChannelClosing -> true
-                    is ChannelAction.Storage.CompleteChannelClosing -> true
+                    is ChannelAction.Storage.StoreChannelClosed -> true
                     else -> false
                 }
             })

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -1546,7 +1546,8 @@ class ClosingTestsCommon : EclairTestSuite() {
             val alice1 = run {
                 val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(alice1 is Closing)
-                assertEquals(6, actions1.size)
+                assertEquals(7, actions1.size)
+                assertTrue(actions1.contains(ChannelAction.Storage.PaymentSent(alice1.commitments.localCommit.spec.toLocal)))
 
                 val error = actions1.hasOutgoingMessage<Error>()
                 assertEquals(ForcedLocalCommit(alice.channelId).message, error.toAscii())
@@ -1572,7 +1573,8 @@ class ClosingTestsCommon : EclairTestSuite() {
             val bob1 = run {
                 val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(bob1 is Closing)
-                assertEquals(6, actions1.size)
+                assertEquals(7, actions1.size)
+                assertTrue(actions1.contains(ChannelAction.Storage.PaymentSent(bob1.commitments.localCommit.spec.toLocal)))
 
                 val error = actions1.hasOutgoingMessage<Error>()
                 assertEquals(ForcedLocalCommit(alice.channelId).message, error.toAscii())

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -165,7 +165,10 @@ class ClosingTestsCommon : EclairTestSuite() {
 
         val (aliceClosed, actions) = alice.processEx(ChannelEvent.WatchReceived(watchConfirmed.last()))
         assertTrue(aliceClosed is Closed)
-        assertEquals(listOf(ChannelAction.Storage.StoreState(aliceClosed)), actions)
+        assertEquals(
+            listOf(ChannelAction.Storage.StoreState(aliceClosed)),
+            actions.filterIsInstance<ChannelAction.Storage.StoreState>()
+        )
     }
 
     @Test
@@ -453,12 +456,13 @@ class ClosingTestsCommon : EclairTestSuite() {
 
         val (aliceClosed, actions) = alice.processEx(ChannelEvent.WatchReceived(watchConfirmed.last()))
         assertTrue(aliceClosed is Closed)
-        assertEquals(2, actions.size)
         assertTrue(actions.contains(ChannelAction.Storage.StoreState(aliceClosed)))
+        assertNotNull(actions.filterIsInstance<ChannelAction.Storage.CompleteChannelClosing>().firstOrNull())
         // We notify the payment handler that the non-dust htlc has been failed.
         val htlcFail = actions.filterIsInstance<ChannelAction.ProcessCmdRes.AddSettledFail>().first()
         assertEquals(htlcs[0], htlcFail.htlc)
         assertTrue(htlcFail.result is ChannelAction.HtlcResult.Fail.OnChainFail)
+        assertEquals(3, actions.size)
     }
 
     @Test
@@ -905,7 +909,11 @@ class ClosingTestsCommon : EclairTestSuite() {
 
         val (alice5, aliceActions5) = alice4.processEx(ChannelEvent.WatchReceived(WatchEventConfirmed(alice0.channelId, BITCOIN_TX_CONFIRMED(aliceTxs[0]), 60, 3, aliceTxs[0])))
         assertTrue(alice5 is Closed)
-        assertEquals(listOf(ChannelAction.Storage.StoreState(alice5)), aliceActions5)
+        assertEquals(
+            listOf(ChannelAction.Storage.StoreState(alice5)),
+            aliceActions5.filterIsInstance<ChannelAction.Storage.StoreState>()
+        )
+        assertEquals(1, aliceActions5.filterIsInstance<ChannelAction.Storage.CompleteChannelClosing>().size)
     }
 
     @Test
@@ -1536,8 +1544,15 @@ class ClosingTestsCommon : EclairTestSuite() {
             val (aliceClosed, actions) = alice.processEx(ChannelEvent.WatchReceived(watchConfirmed.last()))
             assertTrue(aliceClosed is Closed)
             assertTrue(actions.contains(ChannelAction.Storage.StoreState(aliceClosed)))
-            // The only other possible actions are for settling htlcs
-            assertEquals(actions.size - 1, actions.count { action -> action is ChannelAction.ProcessCmdRes })
+            // The only other possible actions are for settling htlcs & ChannelClosing
+            assertEquals(actions.size - 1, actions.count { action ->
+                when (action) {
+                    is ChannelAction.ProcessCmdRes -> true
+                    is ChannelAction.Storage.StoreChannelClosing -> true
+                    is ChannelAction.Storage.CompleteChannelClosing -> true
+                    else -> false
+                }
+            })
         }
 
         fun initForceClose(): Pair<Closing, Closing> {
@@ -1547,7 +1562,13 @@ class ClosingTestsCommon : EclairTestSuite() {
                 val (alice1, actions1) = alice.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(alice1 is Closing)
                 assertEquals(7, actions1.size)
-                assertTrue(actions1.contains(ChannelAction.Storage.StoreOutgoingAmount(alice1.commitments.localCommit.spec.toLocal)))
+
+                val channelBalance = alice1.commitments.localCommit.spec.toLocal
+                if (channelBalance > 0.msat) {
+                    val ledgerPayment = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
+                    assertNotNull(ledgerPayment)
+                    assertTrue(ledgerPayment.amount == channelBalance)
+                }
 
                 val error = actions1.hasOutgoingMessage<Error>()
                 assertEquals(ForcedLocalCommit(alice.channelId).message, error.toAscii())
@@ -1574,7 +1595,13 @@ class ClosingTestsCommon : EclairTestSuite() {
                 val (bob1, actions1) = bob.process(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
                 assertTrue(bob1 is Closing)
                 assertEquals(7, actions1.size)
-                assertTrue(actions1.contains(ChannelAction.Storage.StoreOutgoingAmount(bob1.commitments.localCommit.spec.toLocal)))
+
+                val channelBalance = bob1.commitments.localCommit.spec.toLocal
+                if (channelBalance > 0.msat) {
+                    val ledgerPayment = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
+                    assertNotNull(ledgerPayment)
+                    assertTrue(ledgerPayment.amount == channelBalance)
+                }
 
                 val error = actions1.hasOutgoingMessage<Error>()
                 assertEquals(ForcedLocalCommit(alice.channelId).message, error.toAscii())

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -39,7 +39,7 @@ class WaitForFundingCreatedTestsCommon : EclairTestSuite() {
         actions1.hasWatch<WatchConfirmed>()
         actions1.has<ChannelAction.ChannelId.IdSwitch>()
         actions1.has<ChannelAction.Storage.StoreState>()
-        actions1.has<ChannelAction.Storage.StoreIncomingAmount>()
+        actions1.contains(ChannelAction.Storage.StoreIncomingAmount(TestConstants.pushMsat, ChannelOrigin.PayToOpenOrigin(ByteVector32.One, 42.sat)))
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -39,7 +39,7 @@ class WaitForFundingCreatedTestsCommon : EclairTestSuite() {
         actions1.hasWatch<WatchConfirmed>()
         actions1.has<ChannelAction.ChannelId.IdSwitch>()
         actions1.has<ChannelAction.Storage.StoreState>()
-        actions1.has<ChannelAction.Storage.PaymentReceived>()
+        actions1.has<ChannelAction.Storage.StoreIncomingAmount>()
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingCreatedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingCreatedTestsCommon.kt
@@ -31,7 +31,7 @@ class WaitForFundingCreatedTestsCommon : EclairTestSuite() {
 
     @Test
     fun `recv FundingCreated (with channel origin)`() {
-        val (_, bob, fundingCreated) = init(ChannelVersion.STANDARD, TestConstants.fundingAmount, TestConstants.pushMsat, ChannelOrigin.PayToOpenOrigin(ByteVector32.One))
+        val (_, bob, fundingCreated) = init(ChannelVersion.STANDARD, TestConstants.fundingAmount, TestConstants.pushMsat, ChannelOrigin.PayToOpenOrigin(ByteVector32.One, 42.sat))
         val (bob1, actions1) = bob.process(ChannelEvent.MessageReceived(fundingCreated))
         assertTrue { bob1 is WaitForFundingConfirmed }
         actions1.findOutgoingMessage<FundingSigned>()

--- a/src/commonTest/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -55,8 +55,8 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertNotNull(dbPayment)
         assertEquals(100_000.msat, dbPayment.recipientAmount)
         assertEquals(invoice.nodeId, dbPayment.recipient)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Failed)
-        assertEquals(FinalFailure.NoAvailableChannels, (dbPayment.status as OutgoingPayment.Status.Failed).reason)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
+        assertEquals(FinalFailure.NoAvailableChannels, (dbPayment.status as OutgoingPayment.Status.Completed.Failed).reason)
         assertTrue(dbPayment.parts.isEmpty())
     }
 
@@ -74,8 +74,8 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         val dbPayment = outgoingPaymentHandler.db.getOutgoingPayment(payment.paymentId)
         assertNotNull(dbPayment)
         assertEquals(amount, dbPayment.recipientAmount)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Failed)
-        assertEquals(FinalFailure.InsufficientBalance, (dbPayment.status as OutgoingPayment.Status.Failed).reason)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
+        assertEquals(FinalFailure.InsufficientBalance, (dbPayment.status as OutgoingPayment.Status.Completed.Failed).reason)
         assertTrue(dbPayment.parts.isEmpty())
     }
 
@@ -230,7 +230,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success.payment.recipient)
         assertEquals(invoice.paymentHash, success.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success.payment.details)
-        assertEquals(preimage, (success.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(1, success.payment.parts.size)
         val part = success.payment.parts.first()
         assertNotEquals(part.id, payment.paymentId)
@@ -292,7 +292,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(310_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -344,7 +344,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(310_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -399,7 +399,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(TestConstants.Bob.nodeParams.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(300_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -470,7 +470,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(301_030.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -478,7 +478,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         val dbPayment2 = outgoingPaymentHandler.db.getOutgoingPayment(payment.paymentId)
         assertNotNull(dbPayment2)
-        assertTrue(dbPayment2.status is OutgoingPayment.Status.Succeeded)
+        assertTrue(dbPayment2.status is OutgoingPayment.Status.Completed.Succeeded.OffChain)
         assertEquals(2, dbPayment2.parts.size)
         assertTrue(dbPayment2.parts.all { it.status is OutgoingPayment.Part.Status.Succeeded })
     }
@@ -516,7 +516,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(TestConstants.Bob.nodeParams.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(300_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -801,7 +801,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
             assertEquals(preimage, result2.preimage)
             assertEquals(3, result2.payment.parts.size)
             assertEquals(payment, SendPayment(result2.payment.id, result2.payment.recipientAmount, result2.payment.recipient, result2.payment.details as OutgoingPayment.Details.Normal))
-            assertEquals(preimage, (result2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+            assertEquals(preimage, (result2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         }
     }
 
@@ -886,7 +886,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
     private suspend fun assertDbPaymentFailed(db: OutgoingPaymentsDb, paymentId: UUID, partsCount: Int) {
         val dbPayment = db.getOutgoingPayment(paymentId)
         assertNotNull(dbPayment)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Failed)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
         assertEquals(partsCount, dbPayment.parts.size)
         assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Failed })
     }
@@ -896,7 +896,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertNotNull(dbPayment)
         assertEquals(amount, dbPayment.recipientAmount)
         assertEquals(fees, dbPayment.fees)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Succeeded)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Succeeded.OffChain)
         assertEquals(partsCount, dbPayment.parts.size)
         assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Succeeded })
     }

--- a/src/commonTest/kotlin/fr/acinq/eclair/wire/OpenTlvTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/wire/OpenTlvTestsCommon.kt
@@ -4,6 +4,7 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.channel.ChannelOrigin
 import fr.acinq.eclair.channel.ChannelVersion
 import fr.acinq.eclair.tests.utils.EclairTestSuite
+import fr.acinq.eclair.utils.sat
 import fr.acinq.secp256k1.Hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,8 +38,14 @@ class OpenTlvTestsCommon : EclairTestSuite() {
     @Test
     fun `channel origin TLV`() {
         val testCases = listOf(
-            Pair(ChannelOrigin.PayToOpenOrigin(ByteVector32.fromValidHex("187bf923f7f11ef732b73c417eb5a57cd4667b20a6f130ff505cd7ad3ab87281")), Hex.decode("fe47000003 22 0001 187bf923f7f11ef732b73c417eb5a57cd4667b20a6f130ff505cd7ad3ab87281")),
-            Pair(ChannelOrigin.SwapInOrigin("3AuM8hSkXBetjdHxWthRFiH6hYhqF2Prjr"), Hex.decode("fe47000003 25 0002 223341754d3868536b584265746a644878577468524669483668596871463250726a72")),
+            Pair(
+                ChannelOrigin.PayToOpenOrigin(ByteVector32.fromValidHex("187bf923f7f11ef732b73c417eb5a57cd4667b20a6f130ff505cd7ad3ab87281"), 1234.sat),
+                Hex.decode("fe47000005 2a 0001 187bf923f7f11ef732b73c417eb5a57cd4667b20a6f130ff505cd7ad3ab87281 00000000000004d2")
+            ),
+            Pair(
+                ChannelOrigin.SwapInOrigin("3AuM8hSkXBetjdHxWthRFiH6hYhqF2Prjr", 420.sat),
+                Hex.decode("fe47000005 2d 0002 223341754d3868536b584265746a644878577468524669483668596871463250726a72 00000000000001a4")
+            )
         )
 
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Phoenix-kmm [issue #123](https://github.com/ACINQ/phoenix-kmm/issues/123):

> When the user chooses to close (or force-close) a channel, there should be a corresponding transaction. From the user's perspective, any operation that alters the ledger should have a corresponding transaction.

This PR builds atop of PR #219, which is still pending at the moment. So this PR is blocked until 219 is merged.



Logic overview:

- When a channel transitions to `Closing`, and the channel has a non-zero balance, we inject an OutgoingTransaction into the ledger. The transaction is marked as `Pending`
- When the corresponding channel transitions to `Closed`, we mark the OutgoingTransaction as `Completed.Succeeded.OnChain`, and we record the corresponding txid's & fees.



In terms of code changes, we needed to add a new class to `OutgoingPayment.Details`:

```kotlin
data class ChannelClosing(
   val closingAddress: String,
   val isLocalWallet: Boolean, /*...*/
) : Details()
```



And we refactored `OutgoingPayment.Status` to include support for on-chain payments:

```kotlin
sealed class Status {
   object Pending : Status()
   sealed class Completed : Status() {
      abstract val completedAt: Long
      data class Failed(/*...*/) : Completed()
      sealed class Succeeded : Completed() {
         data class OffChain(/*...*/) : Completed()
         data class OnChain(
            val txids: List<ByteVector32>,
            val claimed: Satoshi,
            override val completedAt: Long
         ) : Completed()
      }
   }
}
```



Here's the code that runs when a channel transitions to the `Closing` state:

<details>
<summary>Code changes in Channel.kt</summary><p>

```kotlin
this is ChannelStateWithCommitments && newState is Closing -> {
   val channelBalance = commitments.localCommit.spec.toLocal
   if (channelBalance > 0.msat) {
      val defaultScriptPubKey = commitments.localParams.defaultFinalScriptPubKey
      val localShutdown = when (this) {
         is Normal -> this.localShutdown
         is Negotiating -> this.localShutdown
         is ShuttingDown -> this.localShutdown
         else -> null
      }
      if (localShutdown != null && localShutdown.scriptPubKey != defaultScriptPubKey) {
         // Non-default output address
         val btcAddr = Helpers.Closing.btcAddressFromScriptPubKey(
            scriptPubKey = localShutdown.scriptPubKey,
            chainHash = staticParams.nodeParams.chainHash
         ) ?: "unknown"
         actions + ChannelAction.Storage.StoreChannelClosing(
            amount = channelBalance,
            closingAddress = btcAddr,
            isLocalWallet = false
         )
      } else {
         // Default output address
         val btcAddr = Helpers.Closing.btcAddressFromScriptPubKey(
            scriptPubKey = defaultScriptPubKey,
            chainHash = staticParams.nodeParams.chainHash
         ) ?: "unknown"
         actions + ChannelAction.Storage.StoreChannelClosing(
            amount = channelBalance,
            closingAddress = btcAddr,
            isLocalWallet = true
         )
      }
   } else /* channelBalance <= 0.msat */ {
      actions
   }
}
```

</p></details>

From the user's perspective:

- they had a balance of X on the channel
- the channel was closed (one way or another)
- they see an OutgoingTransaction with amount -X
- this balances the ledger

Of course, the user may not actually receive X on-chain:

- pending HTLC's could go either direction
- millisatoshi's get truncated
- dust gets ignored

I'm taking a simplistic approach right now, and simply recording all on-chain amounts that we successfully "claimed". Any difference between the original amount and the claimed amount is regarded as "fees".

<details>
<summary>Code changes in Channel.kt</summary><p>

```kotlin
private fun completeChannelClosing(additionalConfirmedTx: Transaction?): ChannelAction.Storage.CompleteChannelClosing {
   // We want to give the user the list of btc transactions for their outputs
   val txids = mutableListOf<ByteVector32>()
   var claimed = 0.sat
   additionalConfirmedTx?.let { confirmedTx ->
      mutualClosePublished.firstOrNull { it == confirmedTx }?.let {
         txids += it.txid
         // NB: this code could be much simpler if we knew the localScriptPubKey
         var expectedAmount = commitments.localCommit.spec.toLocal.truncateToSatoshi()
         if (commitments.localParams.isFunder) {
            // we had to pay the closingFees
            val inputAmount = commitments.commitInput.txOut.amount
            val outputAmount = it.txOut.map { it.amount }.sum()
            val feesAmount = outputAmount - inputAmount
            expectedAmount -= feesAmount
         }
         claimed += expectedAmount
      }
   }
   localCommitPublished?.let {
      val confirmedTxids = it.irrevocablySpent.values.toSet()
      val allTxs = listOfNotNull(it.commitTx, it.claimMainDelayedOutputTx) + it.htlcSuccessTxs + it.htlcTimeoutTxs
      val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
      txids += confirmedTxs.map { it.txid }
      claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
   }
   listOfNotNull(
      remoteCommitPublished,
      nextRemoteCommitPublished,
      futureRemoteCommitPublished
   ).forEach {
      val confirmedTxids = it.irrevocablySpent.values.toSet()
      val allTxs = listOfNotNull(it.commitTx, it.claimMainOutputTx) + it.claimHtlcSuccessTxs + it.claimHtlcTimeoutTxs
      val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
      txids += confirmedTxs.map { it.txid }
      claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
   }
   revokedCommitPublished.forEach {
      val confirmedTxids = it.irrevocablySpent.values.toSet()
      val allTxs = listOfNotNull(it.commitTx, it.claimMainOutputTx, it.mainPenaltyTx) + it.htlcPenaltyTxs + it.claimHtlcDelayedPenaltyTxs
      val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
      txids += confirmedTxs.map { it.txid }
      claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
   }
   return ChannelAction.Storage.CompleteChannelClosing(txids, claimed)
}
```

</p></details>
