### PR TITLE
Rework XxxCommitPublishedTypes

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -20,6 +20,7 @@ import fr.acinq.eclair.serialization.Serialization
 import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClosingTx
 import fr.acinq.eclair.transactions.outgoings
 import fr.acinq.eclair.utils.*
 import fr.acinq.eclair.wire.*
@@ -243,9 +244,9 @@ sealed class ChannelState {
         }
     }
 
-    internal fun doPublish(tx: Transaction, channelId: ByteVector32): List<ChannelAction.Blockchain> = listOf(
-        ChannelAction.Blockchain.PublishTx(tx),
-        ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(tx)))
+    internal fun doPublish(tx: ClosingTx, channelId: ByteVector32): List<ChannelAction.Blockchain> = listOf(
+        ChannelAction.Blockchain.PublishTx(tx.tx),
+        ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx.tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(tx.tx)))
     )
 
     fun handleRemoteError(e: Error): Pair<ChannelState, List<ChannelAction>> {
@@ -714,8 +715,9 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
                 val watch = event.watch
                 when {
                     watch is WatchEventSpent -> when {
-                        state is Negotiating && state.closingTxProposed.flatten().map { it.unsignedTx.txid }.contains(watch.tx.txid) -> {
+                        state is Negotiating && state.closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
                             logger.info { "c:${state.channelId} closing tx published: closingTxId=${watch.tx.txid}" }
+                            val closingTx = state.closingTxProposed.flatten().first { it.unsignedTx.tx.txid == watch.tx.txid }.unsignedTx.copy(tx = watch.tx)
                             val nextState = Closing(
                                 staticParams,
                                 currentTip,
@@ -724,7 +726,7 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
                                 null,
                                 currentBlockHeight.toLong(),
                                 state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(watch.tx)
+                                listOf(closingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -959,7 +961,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                             state.remoteShutdown.scriptPubKey.toByteArray(),
                             currentOnChainFeerates.mutualCloseFeerate
                         )
-                        val closingTxProposed1 = state.closingTxProposed + listOf(listOf(ClosingTxProposed(closingTx.tx, closingSigned)))
+                        val closingTxProposed1 = state.closingTxProposed + listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
                         val nextState = state.copy(closingTxProposed = closingTxProposed1)
                         val actions = listOf(
                             ChannelAction.Storage.StoreState(nextState),
@@ -984,8 +986,9 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                 val watch = event.watch
                 when {
                     watch is WatchEventSpent -> when {
-                        state is Negotiating && state.closingTxProposed.flatten().map { it.unsignedTx.txid }.contains(watch.tx.txid) -> {
+                        state is Negotiating && state.closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
                             logger.info { "c:${state.channelId} closing tx published: closingTxId=${watch.tx.txid}" }
+                            val closingTx = state.closingTxProposed.flatten().first { it.unsignedTx.tx.txid == watch.tx.txid }.unsignedTx.copy(tx = watch.tx)
                             val nextState = Closing(
                                 staticParams,
                                 currentTip,
@@ -994,7 +997,7 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 null,
                                 currentBlockHeight.toLong(),
                                 state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(watch.tx)
+                                listOf(closingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -1912,7 +1915,7 @@ data class Normal(
                                             remoteShutdown.scriptPubKey.toByteArray(),
                                             currentOnChainFeerates.mutualCloseFeerate,
                                         )
-                                        listOf(listOf(ClosingTxProposed(closingTx.tx, closingSigned)))
+                                        listOf(listOf(ClosingTxProposed(closingTx, closingSigned)))
                                     } else {
                                         listOf(listOf())
                                     }
@@ -1991,7 +1994,7 @@ data class Normal(
                                             commitments1,
                                             localShutdown,
                                             event.message,
-                                            listOf(listOf(ClosingTxProposed(closingTx.tx, closingSigned))),
+                                            listOf(listOf(ClosingTxProposed(closingTx, closingSigned))),
                                             bestUnpublishedClosingTx = null
                                         )
                                         actions.addAll(listOf(ChannelAction.Storage.StoreState(nextState), ChannelAction.Message.Send(closingSigned)))
@@ -2130,7 +2133,7 @@ data class ShuttingDown(
                                         commitments1,
                                         localShutdown,
                                         remoteShutdown,
-                                        listOf(listOf(ClosingTxProposed(closingTx.tx, closingSigned))),
+                                        listOf(listOf(ClosingTxProposed(closingTx, closingSigned))),
                                         bestUnpublishedClosingTx = null
                                     )
                                     val actions = listOf(
@@ -2178,7 +2181,7 @@ data class ShuttingDown(
                                         commitments1,
                                         localShutdown,
                                         remoteShutdown,
-                                        listOf(listOf(ClosingTxProposed(closingTx.tx, closingSigned))),
+                                        listOf(listOf(ClosingTxProposed(closingTx, closingSigned))),
                                         bestUnpublishedClosingTx = null
                                     )
                                     actions1.addAll(listOf(ChannelAction.Storage.StoreState(nextState), ChannelAction.Message.Send(closingSigned)))
@@ -2294,7 +2297,7 @@ data class Negotiating(
     val localShutdown: Shutdown,
     val remoteShutdown: Shutdown,
     val closingTxProposed: List<List<ClosingTxProposed>>, // one list for every negotiation (there can be several in case of disconnection)
-    val bestUnpublishedClosingTx: Transaction?
+    val bestUnpublishedClosingTx: ClosingTx?
 ) : ChannelStateWithCommitments() {
     init {
         require(closingTxProposed.isNotEmpty()) { "there must always be a list for the current negotiation" }
@@ -2321,7 +2324,7 @@ data class Negotiating(
                 val result = checkSig.map { signedClosingTx -> // this signed closing tx matches event.message.feeSatoshis
                     when {
                         lastLocalClosingFee == event.message.feeSatoshis || lastLocalClosingFee == nextClosingFee || closingTxProposed.flatten().size >= MAX_NEGOTIATION_ITERATIONS -> {
-                            logger.info { "c:$channelId closing tx published: closingTxId=${signedClosingTx.txid}" }
+                            logger.info { "c:$channelId closing tx published: closingTxId=${signedClosingTx.tx.txid}" }
                             val nextState = Closing(
                                 staticParams,
                                 currentTip,
@@ -2334,14 +2337,14 @@ data class Negotiating(
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
-                                ChannelAction.Blockchain.PublishTx(signedClosingTx),
-                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(signedClosingTx)))
+                                ChannelAction.Blockchain.PublishTx(signedClosingTx.tx),
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx.tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(signedClosingTx.tx)))
                             )
                             Pair(nextState, actions)
                         }
                         nextClosingFee == event.message.feeSatoshis -> {
                             // we have converged but they don't have our signature yet
-                            logger.info { "c:$channelId closing tx published: closingTxId=${signedClosingTx.txid}" }
+                            logger.info { "c:$channelId closing tx published: closingTxId=${signedClosingTx.tx.txid}" }
                             val (_, closingSigned) = Helpers.Closing.makeClosingTx(keyManager, commitments, localShutdown.scriptPubKey.toByteArray(), remoteShutdown.scriptPubKey.toByteArray(), nextClosingFee)
                             val nextState = Closing(
                                 staticParams,
@@ -2355,8 +2358,8 @@ data class Negotiating(
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
-                                ChannelAction.Blockchain.PublishTx(signedClosingTx),
-                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(signedClosingTx))),
+                                ChannelAction.Blockchain.PublishTx(signedClosingTx.tx),
+                                ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, signedClosingTx.tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(signedClosingTx.tx))),
                                 ChannelAction.Message.Send(closingSigned)
                             )
                             Pair(nextState, actions)
@@ -2366,12 +2369,12 @@ data class Negotiating(
                             logger.info { "c:$channelId proposing closingFeeSatoshis=${closingSigned.feeSatoshis}" }
                             val closingProposed1 = closingTxProposed.updated(
                                 closingTxProposed.lastIndex,
-                                closingTxProposed.last() + listOf(ClosingTxProposed(closingTx.tx, closingSigned))
+                                closingTxProposed.last() + listOf(ClosingTxProposed(closingTx, closingSigned))
                             )
                             val nextState = this.copy(
                                 commitments = commitments.copy(remoteChannelData = event.message.channelData),
                                 closingTxProposed = closingProposed1,
-                                bestUnpublishedClosingTx = closingTx.tx
+                                bestUnpublishedClosingTx = closingTx
                             )
                             val actions = listOf(ChannelAction.Storage.StoreState(nextState), ChannelAction.Message.Send(closingSigned))
                             Pair(nextState, actions)
@@ -2386,9 +2389,10 @@ data class Negotiating(
             event is ChannelEvent.MessageReceived && event.message is Error -> handleRemoteError(event.message)
             event is ChannelEvent.WatchReceived -> when (val watch = event.watch) {
                 is WatchEventSpent -> when {
-                    watch.event is BITCOIN_FUNDING_SPENT && closingTxProposed.flatten().map { it.unsignedTx.txid }.contains(watch.tx.txid) -> {
+                    watch.event is BITCOIN_FUNDING_SPENT && closingTxProposed.flatten().any { it.unsignedTx.tx.txid == watch.tx.txid } -> {
                         // they can publish a closing tx with any sig we sent them, even if we are not done negotiating
                         logger.info { "c:$channelId closing tx published: closingTxId=${watch.tx.txid}" }
+                        val closingTx = closingTxProposed.flatten().first { it.unsignedTx.tx.txid == watch.tx.txid }.unsignedTx.copy(tx = watch.tx)
                         val nextState = Closing(
                             staticParams,
                             currentTip,
@@ -2397,7 +2401,7 @@ data class Negotiating(
                             null,
                             currentBlockHeight.toLong(),
                             this.closingTxProposed.flatten().map { it.unsignedTx },
-                            listOf(watch.tx)
+                            listOf(closingTx)
                         )
                         val actions = listOf(
                             ChannelAction.Storage.StoreState(nextState),
@@ -2441,8 +2445,8 @@ data class Negotiating(
                 )
                 val actions = listOf(
                     ChannelAction.Storage.StoreState(nextState),
-                    ChannelAction.Blockchain.PublishTx(bestUnpublishedClosingTx),
-                    ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, bestUnpublishedClosingTx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(bestUnpublishedClosingTx)))
+                    ChannelAction.Blockchain.PublishTx(bestUnpublishedClosingTx.tx),
+                    ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, bestUnpublishedClosingTx.tx, staticParams.nodeParams.minDepthBlocks.toLong(), BITCOIN_TX_CONFIRMED(bestUnpublishedClosingTx.tx)))
                 )
                 Pair(nextState, actions)
             }
@@ -2452,7 +2456,7 @@ data class Negotiating(
 }
 
 sealed class ClosingType
-data class MutualClose(val tx: Transaction) : ClosingType()
+data class MutualClose(val tx: ClosingTx) : ClosingType()
 data class LocalClose(val localCommit: LocalCommit, val localCommitPublished: LocalCommitPublished) : ClosingType()
 
 sealed class RemoteClose : ClosingType() {
@@ -2473,8 +2477,8 @@ data class Closing(
     override val commitments: Commitments,
     val fundingTx: Transaction?, // this will be non-empty if we are funder and we got in closing while waiting for our own tx to be published
     val waitingSinceBlock: Long, // how many blocks since we initiated the closing
-    val mutualCloseProposed: List<Transaction> = emptyList(), // all exchanged closing sigs are flattened, we use this only to keep track of what publishable tx they have
-    val mutualClosePublished: List<Transaction> = emptyList(),
+    val mutualCloseProposed: List<ClosingTx> = emptyList(), // all exchanged closing sigs are flattened, we use this only to keep track of what publishable tx they have
+    val mutualClosePublished: List<ClosingTx> = emptyList(),
     val localCommitPublished: LocalCommitPublished? = null,
     val remoteCommitPublished: RemoteCommitPublished? = null,
     val nextRemoteCommitPublished: RemoteCommitPublished? = null,
@@ -2483,13 +2487,12 @@ data class Closing(
 ) : ChannelStateWithCommitments() {
 
     private val spendingTxs: List<Transaction> by lazy {
-        mutualClosePublished + revokedCommitPublished.map { it.commitTx } +
-                listOfNotNull(
-                    localCommitPublished?.commitTx,
-                    remoteCommitPublished?.commitTx,
-                    nextRemoteCommitPublished?.commitTx,
-                    futureRemoteCommitPublished?.commitTx
-                )
+        mutualClosePublished.map { it.tx } + revokedCommitPublished.map { it.commitTx } + listOfNotNull(
+            localCommitPublished?.commitTx,
+            remoteCommitPublished?.commitTx,
+            nextRemoteCommitPublished?.commitTx,
+            futureRemoteCommitPublished?.commitTx
+        )
     }
 
     override fun updateCommitments(input: Commitments): ChannelStateWithCommitments = this.copy(commitments = input)
@@ -2500,13 +2503,14 @@ data class Closing(
                 val watch = event.watch
                 when {
                     watch is WatchEventSpent && watch.event is BITCOIN_FUNDING_SPENT -> when {
-                        mutualClosePublished.contains(watch.tx) -> {
+                        mutualClosePublished.any { it.tx.txid == watch.tx.txid } -> {
                             // we already know about this tx, probably because we have published it ourselves after successful negotiation
                             Pair(this, listOf())
                         }
-                        mutualCloseProposed.contains(watch.tx) -> {
+                        mutualCloseProposed.any { it.tx.txid == watch.tx.txid } -> {
                             // at any time they can publish a closing tx with any sig we sent them
-                            val nextState = this.copy(mutualClosePublished = this.mutualClosePublished + listOf(watch.tx))
+                            val closingTx = mutualCloseProposed.first { it.tx.txid == watch.tx.txid }.copy(tx = watch.tx)
+                            val nextState = this.copy(mutualClosePublished = this.mutualClosePublished + listOf(closingTx))
                             val actions = listOf(ChannelAction.Storage.StoreState(nextState), ChannelAction.Blockchain.PublishTx(watch.tx))
                             Pair(nextState, actions)
                         }
@@ -2551,8 +2555,8 @@ data class Closing(
                         val revokedCommitPublished1 = revokedCommitPublished.map { rev ->
                             val (newRevokedCommitPublished, tx) = Helpers.Closing.claimRevokedHtlcTxOutputs(keyManager, commitments, rev, watch.tx, currentOnChainFeerates)
                             tx?.let {
-                                revokedCommitPublishActions += ChannelAction.Blockchain.PublishTx(it)
-                                revokedCommitPublishActions += ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, watch.tx, it.txIn.first().outPoint.index.toInt(), BITCOIN_OUTPUT_SPENT))
+                                revokedCommitPublishActions += ChannelAction.Blockchain.PublishTx(it.tx)
+                                revokedCommitPublishActions += ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, watch.tx, it.input.outPoint.index.toInt(), BITCOIN_OUTPUT_SPENT))
                             }
                             newRevokedCommitPublished
                         }
@@ -2740,7 +2744,10 @@ data class Closing(
      */
     private fun isClosed(additionalConfirmedTx: Transaction?): ClosingType? {
         return when {
-            additionalConfirmedTx?.let { mutualClosePublished.contains(it) } ?: false -> MutualClose(additionalConfirmedTx!!)
+            additionalConfirmedTx?.let { tx -> mutualClosePublished.any { it.tx.txid == tx.txid } } ?: false -> {
+                val closingTx = mutualClosePublished.first { it.tx.txid == additionalConfirmedTx!!.txid }.copy(tx = additionalConfirmedTx!!)
+                MutualClose(closingTx)
+            }
             localCommitPublished?.isDone() ?: false -> LocalClose(commitments.localCommit, localCommitPublished!!)
             remoteCommitPublished?.isDone() ?: false -> CurrentRemoteClose(commitments.remoteCommit, remoteCommitPublished!!)
             nextRemoteCommitPublished?.isDone() ?: false -> NextRemoteClose(commitments.remoteNextCommitInfo.left!!.nextRemoteCommit, nextRemoteCommitPublished!!)
@@ -2756,7 +2763,7 @@ data class Closing(
             remoteCommitPublished?.isConfirmed() ?: false -> CurrentRemoteClose(commitments.remoteCommit, remoteCommitPublished!!)
             nextRemoteCommitPublished?.isConfirmed() ?: false -> NextRemoteClose(commitments.remoteNextCommitInfo.left!!.nextRemoteCommit, nextRemoteCommitPublished!!)
             futureRemoteCommitPublished?.isConfirmed() ?: false -> RecoveryClose(futureRemoteCommitPublished!!)
-            revokedCommitPublished.any { it.irrevocablySpent.values.contains(it.commitTx.txid) } -> RevokedClose(revokedCommitPublished.first { it.irrevocablySpent.values.contains(it.commitTx.txid) })
+            revokedCommitPublished.any { it.isConfirmed() } -> RevokedClose(revokedCommitPublished.first { it.isConfirmed() })
             else -> null
         }
     }
@@ -2769,55 +2776,67 @@ data class Closing(
      * @return if the parent tx is found, a tuple (fee, description)
      */
     private fun networkFeePaid(tx: Transaction): Pair<Satoshi, String>? {
-        // only funder pays the fee
-        if (!commitments.localParams.isFunder) return null
+        // only the funder pays the fee for the commit tx, but 2nd-stage and 3rd-stage tx fees are paid by their recipients
+        // we can compute the fees only for transactions with a single parent for which we know the output amount
+        val isCommitTx = tx.txIn.any { it.outPoint == commitments.commitInput.outPoint }
+        if (tx.txIn.size != 1) return null
+        if (isCommitTx && !commitments.localParams.isFunder) return null
 
         // we build a map with all known txs (that's not particularly efficient, but it doesn't really matter)
         val txs = buildList {
-            mutualClosePublished.map { it to "mutual" }.forEach { add(it) }
+            mutualClosePublished.map { it.tx to "mutual" }.forEach { add(it) }
             localCommitPublished?.let { localCommitPublished ->
                 add(localCommitPublished.commitTx to "local-commit")
-                localCommitPublished.claimMainDelayedOutputTx?.let { add(it to "local-main-delayed") }
-                localCommitPublished.htlcSuccessTxs.forEach { add(it to "local-htlc-success") }
-                localCommitPublished.htlcTimeoutTxs.forEach { add(it to "local-htlc-timeout") }
-                localCommitPublished.claimHtlcDelayedTxs.forEach { add(it to "local-htlc-delayed") }
+                localCommitPublished.claimMainDelayedOutputTx?.let { add(it.tx to "local-main-delayed") }
+                localCommitPublished.htlcTxs.values.forEach {
+                    when (it) {
+                        is Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx -> add(it.tx to "local-htlc-success")
+                        is Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx -> add(it.tx to "local-htlc-timeout")
+                    }
+                }
+                localCommitPublished.claimHtlcDelayedTxs.forEach { add(it.tx to "local-htlc-delayed") }
             }
             remoteCommitPublished?.let { remoteCommitPublished ->
                 add(remoteCommitPublished.commitTx to "remote-commit")
-                remoteCommitPublished.claimMainOutputTx?.let { add(it to "remote-main") }
-                remoteCommitPublished.claimHtlcSuccessTxs.forEach { add(it to "remote-htlc-success") }
-                remoteCommitPublished.claimHtlcTimeoutTxs.forEach { add(it to "remote-htlc-timeout") }
+                remoteCommitPublished.claimMainOutputTx?.let { add(it.tx to "remote-main") }
+                remoteCommitPublished.claimHtlcTxs.values.forEach {
+                    when (it) {
+                        is Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcSuccessTx -> add(it.tx to "remote-htlc-success")
+                        is Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcTimeoutTx -> add(it.tx to "remote-htlc-timeout")
+                    }
+                }
             }
             nextRemoteCommitPublished?.let { nextRemoteCommitPublished ->
                 add(nextRemoteCommitPublished.commitTx to "remote-commit")
-                nextRemoteCommitPublished.claimMainOutputTx?.let { add(it to "remote-main") }
-                nextRemoteCommitPublished.claimHtlcSuccessTxs.forEach { add(it to "remote-htlc-success") }
-                nextRemoteCommitPublished.claimHtlcTimeoutTxs.forEach { add(it to "remote-htlc-timeout") }
+                nextRemoteCommitPublished.claimMainOutputTx?.let { add(it.tx to "remote-main") }
+                nextRemoteCommitPublished.claimHtlcTxs.values.forEach {
+                    when (it) {
+                        is Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcSuccessTx -> add(it.tx to "remote-htlc-success")
+                        is Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcTimeoutTx -> add(it.tx to "remote-htlc-timeout")
+                    }
+                }
             }
             revokedCommitPublished.forEach { revokedCommitPublished ->
                 add(revokedCommitPublished.commitTx to "revoked-commit")
-                revokedCommitPublished.claimMainOutputTx?.let { add(it to "revoked-main") }
-                revokedCommitPublished.mainPenaltyTx?.let { add(it to "revoked-main-penalty") }
-                revokedCommitPublished.htlcPenaltyTxs.forEach { add(it to "revoked-htlc-penalty") }
-                revokedCommitPublished.claimHtlcDelayedPenaltyTxs.forEach { add(it to "revoked-htlc-penalty-delayed") }
+                revokedCommitPublished.claimMainOutputTx?.let { add(it.tx to "revoked-main") }
+                revokedCommitPublished.mainPenaltyTx?.let { add(it.tx to "revoked-main-penalty") }
+                revokedCommitPublished.htlcPenaltyTxs.forEach { add(it.tx to "revoked-htlc-penalty") }
+                revokedCommitPublished.claimHtlcDelayedPenaltyTxs.forEach { add(it.tx to "revoked-htlc-penalty-delayed") }
             }
         }.map { (tx, desc) ->
             // will allow easy lookup of parent transaction
             tx.txid to (tx to desc)
         }.toMap()
 
-        fun fee(child: Transaction): Satoshi? {
-            require(child.txIn.size == 1) { "transaction must have exactly one input" }
-            val outPoint = child.txIn.first().outPoint
-            val parentTxOut = if (outPoint == commitments.commitInput.outPoint) {
+        return txs[tx.txid]?.let { (_, desc) ->
+            val parentTxOut = if (isCommitTx) {
                 commitments.commitInput.txOut
             } else {
+                val outPoint = tx.txIn.first().outPoint
                 txs[outPoint.txid]?.let { (parent, _) -> parent.txOut[outPoint.index.toInt()] }
             }
-            return parentTxOut?.let { txOut -> txOut.amount - child.txOut.map { it.amount }.sum() }
+            parentTxOut?.let { txOut -> txOut.amount - tx.txOut.map { it.amount }.sum() }?.let { it to desc }
         }
-
-        return txs[tx.txid]?.let { (_, desc) -> fee(tx)?.let { it to desc } }
     }
 }
 

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -578,7 +578,7 @@ data class WaitForInit(override val staticParams: StaticParams, override val cur
             }
             event is ChannelEvent.Restore && event.state is Closing -> {
                 val closingType = event.state.closingTypeAlreadyKnown()
-                logger.info { "c:${event.state.channelId} channel is closing (closing type = ${closingType?.let { it::class } ?: "unknown yet"}" }
+                logger.info { "c:${event.state.channelId} channel is closing (closing type = ${closingType?.let { it::class } ?: "unknown yet"})" }
                 // if the closing type is known:
                 // - there is no need to watch the funding tx because it has already been spent and the spending tx has
                 //   already reached mindepth
@@ -2250,6 +2250,7 @@ data class ShuttingDown(
                 event.command is CMD_FAIL_MALFORMED_HTLC -> handleCommandResult(event.command, commitments.sendFailMalformed(event.command), event.command.commit)
                 event.command is CMD_UPDATE_FEE -> handleCommandResult(event.command, commitments.sendFee(event.command), event.command.commit)
                 event.command is CMD_CLOSE -> handleCommandError(event.command, ClosingAlreadyInProgress(channelId))
+                event.command is CMD_FORCECLOSE -> handleLocalError(event, ForcedLocalCommit(channelId))
                 else -> unhandled(event)
             }
             is ChannelEvent.WatchReceived -> when (val watch = event.watch) {

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
@@ -137,21 +137,19 @@ data class LocalCommitPublished(
     }
 
     fun isHtlcTimeout(tx: Transaction): Boolean {
-        return tx.txIn.filter {
-            when (htlcTxs[it.outPoint]) {
-                is HtlcTx.HtlcTimeoutTx -> true
-                else -> false
-            }
-        }.map { it.witness }.mapNotNull(Scripts.extractPaymentHashFromHtlcTimeout()).isNotEmpty()
+        return tx.txIn
+            .filter { htlcTxs[it.outPoint] is HtlcTx.HtlcTimeoutTx }
+            .map { it.witness }
+            .mapNotNull(Scripts.extractPaymentHashFromHtlcTimeout())
+            .isNotEmpty()
     }
 
     fun isHtlcSuccess(tx: Transaction): Boolean {
-        return tx.txIn.filter {
-            when (htlcTxs[it.outPoint]) {
-                is HtlcTx.HtlcSuccessTx -> true
-                else -> false
-            }
-        }.map { it.witness }.mapNotNull(Scripts.extractPreimageFromHtlcSuccess()).isNotEmpty()
+        return tx.txIn
+            .filter { htlcTxs[it.outPoint] is HtlcTx.HtlcSuccessTx }
+            .map { it.witness }
+            .mapNotNull(Scripts.extractPreimageFromHtlcSuccess())
+            .isNotEmpty()
     }
 
     internal fun doPublish(channelId: ByteVector32, minDepth: Long): List<ChannelAction> {
@@ -246,21 +244,19 @@ data class RemoteCommitPublished(
     }
 
     fun isClaimHtlcTimeout(tx: Transaction): Boolean {
-        return tx.txIn.filter {
-            when (claimHtlcTxs[it.outPoint]) {
-                is ClaimHtlcTx.ClaimHtlcTimeoutTx -> true
-                else -> false
-            }
-        }.map { it.witness }.mapNotNull(Scripts.extractPaymentHashFromClaimHtlcTimeout()).isNotEmpty()
+        return tx.txIn
+            .filter { claimHtlcTxs[it.outPoint] is ClaimHtlcTx.ClaimHtlcTimeoutTx }
+            .map { it.witness }
+            .mapNotNull(Scripts.extractPaymentHashFromClaimHtlcTimeout())
+            .isNotEmpty()
     }
 
     fun isClaimHtlcSuccess(tx: Transaction): Boolean {
-        return tx.txIn.filter {
-            when (claimHtlcTxs[it.outPoint]) {
-                is ClaimHtlcTx.ClaimHtlcSuccessTx -> true
-                else -> false
-            }
-        }.map { it.witness }.mapNotNull(Scripts.extractPreimageFromClaimHtlcSuccess()).isNotEmpty()
+        return tx.txIn
+            .filter { claimHtlcTxs[it.outPoint] is ClaimHtlcTx.ClaimHtlcSuccessTx }
+            .map { it.witness }
+            .mapNotNull(Scripts.extractPreimageFromClaimHtlcSuccess())
+            .isNotEmpty()
     }
 
     internal fun doPublish(channelId: ByteVector32, minDepth: Long): List<ChannelAction> {

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/ChannelTypes.kt
@@ -107,7 +107,7 @@ data class LocalCommitPublished(
             isCommitTx || spendsTheCommitTx || is3rdStageDelayedTx
         }
         // then we add the relevant outpoints to the map keeping track of which txid spends which outpoint
-        return this.copy(irrevocablySpent = irrevocablySpent + relevantOutpoints.map { it to tx }.toMap())
+        return this.copy(irrevocablySpent = irrevocablySpent + relevantOutpoints.associateWith { tx }.toMap())
     }
 
     /**
@@ -221,7 +221,7 @@ data class RemoteCommitPublished(
             isCommitTx || spendsTheCommitTx
         }
         // then we add the relevant outpoints to the map keeping track of which txid spends which outpoint
-        return this.copy(irrevocablySpent = irrevocablySpent + relevantOutpoints.map { it to tx }.toMap())
+        return this.copy(irrevocablySpent = irrevocablySpent + relevantOutpoints.associateWith { tx }.toMap())
     }
 
     /**
@@ -330,7 +330,7 @@ data class RevokedCommitPublished(
             isCommitTx || spendsTheCommitTx || is3rdStageDelayedTx
         }
         // then we add the relevant outpoints to the map keeping track of which txid spends which outpoint
-        return this.copy(irrevocablySpent = irrevocablySpent + relevantOutpoints.map { it to tx }.toMap())
+        return this.copy(irrevocablySpent = irrevocablySpent + relevantOutpoints.associateWith { tx }.toMap())
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Helpers.kt
@@ -19,9 +19,17 @@ import fr.acinq.eclair.channel.Helpers.Closing.inputsAlreadySpent
 import fr.acinq.eclair.crypto.Generators
 import fr.acinq.eclair.crypto.KeyManager
 import fr.acinq.eclair.transactions.*
+import fr.acinq.eclair.transactions.Scripts.extractPaymentHashFromClaimHtlcTimeout
+import fr.acinq.eclair.transactions.Scripts.extractPaymentHashFromHtlcTimeout
+import fr.acinq.eclair.transactions.Scripts.extractPreimageFromClaimHtlcSuccess
+import fr.acinq.eclair.transactions.Scripts.extractPreimageFromHtlcSuccess
 import fr.acinq.eclair.transactions.Scripts.multiSig2of2
-import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.HtlcSuccessTx
-import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.HtlcTimeoutTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClaimHtlcDelayedOutputPenaltyTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcSuccessTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcTimeoutTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClosingTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx
 import fr.acinq.eclair.transactions.Transactions.commitTxFee
 import fr.acinq.eclair.transactions.Transactions.makeCommitTxOutputs
 import fr.acinq.eclair.utils.*
@@ -256,7 +264,7 @@ object Helpers {
     }
 
     /** This helper method will publish txs only if they haven't yet reached minDepth. */
-    fun publishIfNeeded(txs: List<Transaction>, irrevocablySpent: Map<OutPoint, ByteVector32>, channelId: ByteVector32): List<ChannelAction.Blockchain.PublishTx> {
+    fun publishIfNeeded(txs: List<Transaction>, irrevocablySpent: Map<OutPoint, Transaction>, channelId: ByteVector32): List<ChannelAction.Blockchain.PublishTx> {
         val (skip, process) = txs.partition { it.inputsAlreadySpent(irrevocablySpent) }
         skip.forEach { tx -> logger.info { "c:$channelId no need to republish txid=${tx.txid}, it has already been confirmed" } }
         return process.map { tx ->
@@ -266,17 +274,20 @@ object Helpers {
     }
 
     /** This helper method will watch txs only if they haven't yet reached minDepth. */
-    fun watchConfirmedIfNeeded(txs: List<Transaction>, irrevocablySpent: Map<OutPoint, ByteVector32>, channelId: ByteVector32, minDepth: Long): List<ChannelAction.Blockchain.SendWatch> {
+    fun watchConfirmedIfNeeded(txs: List<Transaction>, irrevocablySpent: Map<OutPoint, Transaction>, channelId: ByteVector32, minDepth: Long): List<ChannelAction.Blockchain.SendWatch> {
         val (skip, process) = txs.partition { it.inputsAlreadySpent(irrevocablySpent) }
         skip.forEach { tx -> logger.info { "c:$channelId no need to watch txid=${tx.txid}, it has already been confirmed" } }
         return process.map { tx -> ChannelAction.Blockchain.SendWatch(WatchConfirmed(channelId, tx, minDepth, BITCOIN_TX_CONFIRMED(tx))) }
     }
 
     /** This helper method will watch txs only if the utxo they spend hasn't already been irrevocably spent. */
-    fun watchSpentIfNeeded(parentTx: Transaction, txs: List<Transaction>, irrevocablySpent: Map<OutPoint, ByteVector32>, channelId: ByteVector32): List<ChannelAction.Blockchain.SendWatch> {
-        val (skip, process) = txs.partition { it.inputsAlreadySpent(irrevocablySpent) }
-        skip.forEach { tx -> logger.info { "c:$channelId no need to watch txid=${tx.txid}, it has already been confirmed" } }
-        return process.map { ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, parentTx, it.txIn.first().outPoint.index.toInt(), BITCOIN_OUTPUT_SPENT)) }
+    fun watchSpentIfNeeded(parentTx: Transaction, outputs: List<OutPoint>, irrevocablySpent: Map<OutPoint, Transaction>, channelId: ByteVector32): List<ChannelAction.Blockchain.SendWatch> {
+        val (skip, process) = outputs.partition { irrevocablySpent.contains(it) }
+        skip.forEach { output -> logger.info { "c:$channelId no need to watch output=${output.txid}:${output.index}, it has already been spent by txid=${irrevocablySpent[output]?.txid}" } }
+        return process.map { output ->
+            require(output.txid == parentTx.txid) { "output doesn't belong to the given parentTx: txid=${output.txid} but expected txid=${parentTx.txid}" }
+            ChannelAction.Blockchain.SendWatch(WatchSpent(channelId, parentTx, output.index.toInt(), BITCOIN_OUTPUT_SPENT))
+        }
     }
 
     object Funding {
@@ -403,11 +414,11 @@ object Helpers {
             remoteScriptPubkey: ByteArray,
             remoteClosingFee: Satoshi,
             remoteClosingSig: ByteVector64
-        ): Either<ChannelException, Transaction> {
+        ): Either<ChannelException, ClosingTx> {
             val (closingTx, closingSigned) = makeClosingTx(keyManager, commitments, localScriptPubkey, remoteScriptPubkey, remoteClosingFee)
             val signedClosingTx = Transactions.addSigs(closingTx, keyManager.fundingPublicKey(commitments.localParams.fundingKeyPath).publicKey, commitments.remoteParams.fundingPubKey, closingSigned.signature, remoteClosingSig)
             return when (Transactions.checkSpendable(signedClosingTx)) {
-                is Try.Success -> Either.Right(signedClosingTx.tx)
+                is Try.Success -> Either.Right(signedClosingTx)
                 is Try.Failure -> Either.Left(InvalidCloseSignature(commitments.channelId, signedClosingTx.tx))
             }
         }
@@ -442,30 +453,28 @@ object Helpers {
                 )
             }?.let {
                 val sig = keyManager.sign(it, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint, SigHash.SIGHASH_ALL)
-                Transactions.addSigs(it, sig).tx
+                Transactions.addSigs(it, sig)
             }
 
             // those are the preimages to existing received htlcs
             val preimages = commitments.localChanges.all.filterIsInstance<UpdateFulfillHtlc>().map { it.paymentPreimage }
 
-            val htlcTxs = localCommit.publishableTxs.htlcTxsAndSigs.mapNotNull { (txInfo, localSig, remoteSig) ->
+            val htlcTxs = localCommit.publishableTxs.htlcTxsAndSigs.map { (txInfo, localSig, remoteSig) ->
                 when (txInfo) {
-                    // incoming htlc for which we have the preimage: we spend it directly
-                    // incoming htlc for which we don't have the preimage: nothing to do, it will timeout eventually and they will get their funds back
-                    is HtlcSuccessTx -> {
-                        preimages.firstOrNull { r ->
-                            sha256(r).toByteVector() == txInfo.paymentHash
-                        }?.let { preimage -> Transactions.addSigs(txInfo, localSig, remoteSig, preimage) }
+                    is HtlcSuccessTx -> when (val preimage = preimages.firstOrNull { r -> r.sha256() == txInfo.paymentHash }) {
+                        // incoming htlc for which we don't have the preimage: we can't spend it immediately, but we may learn the
+                        // preimage later, otherwise it will eventually timeout and they will get their funds back
+                        null -> Pair(txInfo.input.outPoint, null)
+                        // incoming htlc for which we have the preimage: we can spend it directly
+                        else -> Pair(txInfo.input.outPoint, Transactions.addSigs(txInfo, localSig, remoteSig, preimage))
                     }
-
                     // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
-                    is HtlcTimeoutTx -> Transactions.addSigs(txInfo, localSig, remoteSig)
-                    else -> null
+                    is HtlcTimeoutTx -> Pair(txInfo.input.outPoint, Transactions.addSigs(txInfo, localSig, remoteSig))
                 }
-            }
+            }.toMap()
 
             // all htlc output to us are delayed, so we need to claim them as soon as the delay is over
-            val htlcDelayedTxs = htlcTxs.mapNotNull { txInfo ->
+            val htlcDelayedTxs = htlcTxs.values.filterNotNull().mapNotNull { txInfo ->
                 generateTx("claim-htlc-delayed") {
                     Transactions.makeClaimLocalDelayedOutputTx(
                         txInfo.tx,
@@ -478,16 +487,17 @@ object Helpers {
                     )
                 }?.let {
                     val sig = keyManager.sign(it, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint, SigHash.SIGHASH_ALL)
-                    Transactions.addSigs(it, sig).tx
+                    Transactions.addSigs(it, sig)
                 }
             }
 
             return LocalCommitPublished(
                 commitTx = tx,
                 claimMainDelayedOutputTx = mainDelayedTx,
-                htlcSuccessTxs = htlcTxs.filterIsInstance<HtlcSuccessTx>().map(HtlcSuccessTx::tx),
-                htlcTimeoutTxs = htlcTxs.filterIsInstance<HtlcTimeoutTx>().map(HtlcTimeoutTx::tx),
-                claimHtlcDelayedTxs = htlcDelayedTxs
+                htlcTxs = htlcTxs,
+                claimHtlcDelayedTxs = htlcDelayedTxs,
+                claimAnchorTxs = emptyList(),
+                irrevocablySpent = emptyMap()
             )
         }
 
@@ -504,7 +514,7 @@ object Helpers {
             val localParams = commitments.localParams
             val remoteParams = commitments.remoteParams
             val commitInput = commitments.commitInput
-            val (remoteCommitTx, _, _) = Commitments.makeRemoteTxs(
+            val (remoteCommitTx, _) = Commitments.makeRemoteTxs(
                 keyManager,
                 channelVersion,
                 remoteCommit.index,
@@ -543,56 +553,58 @@ object Helpers {
             val preimages = commitments.localChanges.all.filterIsInstance<UpdateFulfillHtlc>().map { it.paymentPreimage }
 
             // remember we are looking at the remote commitment so IN for them is really OUT for us and vice versa
-
-            val claimHtlcSuccessTxs = remoteCommit.spec.htlcs.filterIsInstance<OutgoingHtlc>().map { it.add }.mapNotNull { add ->
-                // incoming htlc for which we have the preimage: we spend it directly.
-                // incoming htlc for which we don't have the preimage: nothing to do, it will timeout eventually and they will get their funds back.
-                // NB: we are looking at the remote's commitment, from its point of view it's an outgoing htlc.
-                preimages.firstOrNull { r -> sha256(r).toByteVector() == add.paymentHash }?.let { preimage ->
-                    generateTx("claim-htlc-success") {
-                        Transactions.makeClaimHtlcSuccessTx(
-                            remoteCommitTx.tx,
-                            outputs,
-                            localParams.dustLimit,
-                            localHtlcPubkey,
-                            remoteHtlcPubkey,
-                            remoteRevocationPubkey,
-                            localParams.defaultFinalScriptPubKey.toByteArray(),
-                            add,
-                            feerateClaimHtlc
-                        )
-                    }?.let {
-                        val sig = keyManager.sign(it, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, SigHash.SIGHASH_ALL)
-                        Transactions.addSigs(it, sig, preimage).tx
+            val claimHtlcTxs = remoteCommit.spec.htlcs.mapNotNull { htlc ->
+                when (htlc) {
+                    is OutgoingHtlc -> {
+                        generateTx("claim-htlc-success") {
+                            Transactions.makeClaimHtlcSuccessTx(
+                                remoteCommitTx.tx,
+                                outputs,
+                                localParams.dustLimit,
+                                localHtlcPubkey,
+                                remoteHtlcPubkey,
+                                remoteRevocationPubkey,
+                                localParams.defaultFinalScriptPubKey.toByteArray(),
+                                htlc.add,
+                                feerateClaimHtlc
+                            )
+                        }?.let { claimHtlcTx ->
+                            when (val preimage = preimages.firstOrNull { r -> r.sha256() == htlc.add.paymentHash }) {
+                                // incoming htlc for which we don't have the preimage: we can't spend it immediately, but we may learn the
+                                // preimage later, otherwise it will eventually timeout and they will get their funds back
+                                null -> Pair(claimHtlcTx.input.outPoint, null)
+                                // incoming htlc for which we have the preimage: we can spend it directly
+                                else -> {
+                                    val sig = keyManager.sign(claimHtlcTx, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, SigHash.SIGHASH_ALL)
+                                    Pair(claimHtlcTx.input.outPoint, Transactions.addSigs(claimHtlcTx, sig, preimage))
+                                }
+                            }
+                        }
+                    }
+                    is IncomingHtlc -> {
+                        // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
+                        generateTx("claim-htlc-timeout") {
+                            Transactions.makeClaimHtlcTimeoutTx(
+                                remoteCommitTx.tx,
+                                outputs,
+                                localParams.dustLimit,
+                                localHtlcPubkey,
+                                remoteHtlcPubkey,
+                                remoteRevocationPubkey,
+                                localParams.defaultFinalScriptPubKey.toByteArray(),
+                                htlc.add,
+                                feerateClaimHtlc
+                            )
+                        }?.let { claimHtlcTx ->
+                            val sig = keyManager.sign(claimHtlcTx, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, SigHash.SIGHASH_ALL)
+                            Pair(claimHtlcTx.input.outPoint, Transactions.addSigs(claimHtlcTx, sig))
+                        }
                     }
                 }
-            }
-
-            val claimHtlcTimeoutTxs = remoteCommit.spec.htlcs.filterIsInstance<IncomingHtlc>().map { it.add }.mapNotNull { add ->
-                // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
-                generateTx("claim-htlc-timeout") {
-                    Transactions.makeClaimHtlcTimeoutTx(
-                        remoteCommitTx.tx,
-                        outputs,
-                        localParams.dustLimit,
-                        localHtlcPubkey,
-                        remoteHtlcPubkey,
-                        remoteRevocationPubkey,
-                        localParams.defaultFinalScriptPubKey.toByteArray(),
-                        add,
-                        feerateClaimHtlc
-                    )
-                }?.let {
-                    val sig = keyManager.sign(it, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, SigHash.SIGHASH_ALL)
-                    Transactions.addSigs(it, sig).tx
-                }
-            }
+            }.toMap()
 
             // we claim our output and add the htlc txs we just created
-            return claimRemoteCommitMainOutput(keyManager, commitments, tx, feerates.claimMainFeerate).copy(
-                claimHtlcSuccessTxs = claimHtlcSuccessTxs,
-                claimHtlcTimeoutTxs = claimHtlcTimeoutTxs
-            )
+            return claimRemoteCommitMainOutput(keyManager, commitments, tx, feerates.claimMainFeerate).copy(claimHtlcTxs = claimHtlcTxs)
         }
 
         /**
@@ -617,7 +629,7 @@ object Helpers {
                 )
             }?.let {
                 val sig = keyManager.sign(it, localPaymentPoint)
-                Transactions.addSigs(it, sig).tx
+                Transactions.addSigs(it, sig)
             }
 
             return RemoteCommitPublished(commitTx = tx, claimMainOutputTx = mainTx)
@@ -676,7 +688,7 @@ object Helpers {
                 )
             }?.let {
                 val sig = keyManager.sign(it, localPaymentPoint)
-                Transactions.addSigs(it, sig).tx
+                Transactions.addSigs(it, sig)
             }
 
             // then we punish them by stealing their main output
@@ -692,7 +704,7 @@ object Helpers {
                 )
             }?.let {
                 val sig = keyManager.sign(it, keyManager.revocationPoint(channelKeyPath), remotePerCommitmentSecret)
-                Transactions.addSigs(it, sig).tx
+                Transactions.addSigs(it, sig)
             }
 
             return Pair(RevokedCommitPublished(commitTx = tx, remotePerCommitmentSecret = remotePerCommitmentSecret, claimMainOutputTx = mainTx, mainPenaltyTx = mainPenaltyTx), txNumber)
@@ -739,7 +751,7 @@ object Helpers {
                         )
                     }?.let { htlcPenaltyTx ->
                         val sig = keyManager.sign(htlcPenaltyTx, keyManager.revocationPoint(channelKeyPath), revokedCommitPublished.remotePerCommitmentSecret)
-                        Transactions.addSigs(htlcPenaltyTx, sig, remoteRevocationPubkey).tx
+                        Transactions.addSigs(htlcPenaltyTx, sig, remoteRevocationPubkey)
                     }
                 }
             }
@@ -751,20 +763,26 @@ object Helpers {
          * Claims the output of an [[HtlcSuccessTx]] or [[HtlcTimeoutTx]] transaction using a revocation key.
          *
          * In case a revoked commitment with pending HTLCs is published, there are two ways the HTLC outputs can be taken as punishment:
-         * - by spending the corresponding output of the commitment tx, using [[HtlcPenaltyTx]] that we generate as soon as we detect that a revoked commit
+         * - by spending the corresponding output of the commitment tx, using [[ClaimHtlcDelayedOutputPenaltyTx]] that we generate as soon as we detect that a revoked commit
          * has been spent; note that those transactions will compete with [[HtlcSuccessTx]] and [[HtlcTimeoutTx]] published by the counterparty.
          * - by spending the delayed output of [[HtlcSuccessTx]] and [[HtlcTimeoutTx]] if those get confirmed; because the output of these txs is protected by
          * an OP_CSV delay, we will have time to spend them with a revocation key. In that case, we generate the spending transactions "on demand",
          * this is the purpose of this method.
          */
-        fun claimRevokedHtlcTxOutputs(keyManager: KeyManager, commitments: Commitments, revokedCommitPublished: RevokedCommitPublished, htlcTx: Transaction, feerates: OnChainFeerates): Pair<RevokedCommitPublished, Transaction?> {
+        fun claimRevokedHtlcTxOutputs(
+            keyManager: KeyManager,
+            commitments: Commitments,
+            revokedCommitPublished: RevokedCommitPublished,
+            htlcTx: Transaction,
+            feerates: OnChainFeerates
+        ): Pair<RevokedCommitPublished, ClaimHtlcDelayedOutputPenaltyTx?> {
             val claimTxs = buildList {
                 revokedCommitPublished.claimMainOutputTx?.let { add(it) }
                 revokedCommitPublished.mainPenaltyTx?.let { add(it) }
                 addAll(revokedCommitPublished.htlcPenaltyTxs)
             }
-
-            if (htlcTx.txIn.map { it.outPoint.txid }.contains(revokedCommitPublished.commitTx.txid) && !claimTxs.map { it.txid }.toSet().contains(htlcTx.txid)) {
+            val isHtlcTx = htlcTx.txIn.any { it.outPoint.txid == revokedCommitPublished.commitTx.txid } && !claimTxs.any { it.tx.txid == htlcTx.txid }
+            if (isHtlcTx) {
                 logger.info { "c:${commitments.channelId} looks like txid=${htlcTx.txid} could be a 2nd level htlc tx spending revoked commit txid=${revokedCommitPublished.commitTx.txid}" }
                 // Let's assume that htlcTx is an HtlcSuccessTx or HtlcTimeoutTx and try to generate a tx spending its output using a revocation key
                 val channelKeyPath = keyManager.channelKeyPath(commitments.localParams, commitments.channelVersion)
@@ -787,9 +805,9 @@ object Helpers {
                     )
                 }?.let {
                     val sig = keyManager.sign(it, keyManager.revocationPoint(channelKeyPath), revokedCommitPublished.remotePerCommitmentSecret)
-                    val signedTx = Transactions.addSigs(it, sig).tx
+                    val signedTx = Transactions.addSigs(it, sig)
                     // we need to make sure that the tx is indeed valid
-                    when (runTrying { Transaction.correctlySpends(signedTx, listOf(htlcTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS) }) {
+                    when (runTrying { Transaction.correctlySpends(signedTx.tx, listOf(htlcTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS) }) {
                         is Try.Success -> signedTx
                         is Try.Failure -> null
                     }
@@ -828,32 +846,40 @@ object Helpers {
             }.toSet()
         }
 
-        /**
-         * We may have multiple HTLCs with the same payment hash because of MPP.
-         * When a timeout transaction is confirmed, we need to find the best matching HTLC to fail upstream.
-         * We need to handle potentially duplicate HTLCs (same amount and expiry): this function will use a deterministic
-         * ordering of transactions and HTLCs to handle this.
-         */
-        private fun Transaction.findTimedOutHtlc(paymentHash160: ByteVector, htlcs: List<UpdateAddHtlc>, timeoutTxs: List<Transaction>, extractPaymentHash: (ScriptWitness) -> ByteVector?): UpdateAddHtlc? {
-            // We use a deterministic ordering to match HTLCs to their corresponding HTLC-timeout tx.
-            // We don't match on the expected amounts because this is error-prone: computing the correct weight of a claim-htlc-timeout
-            // is hard because signatures can be either 71, 72 or 73 bytes long (ECDSA DER encoding).
-            // We could instead look at the spent outpoint, but that requires more lookups and access to the published commitment transaction.
-            // It's simpler to just use the amount as the first ordering key: since the feerate is the same for all timeout
-            // transactions we will find the right HTLC to fail upstream.
-            val matchingHtlcs = htlcs
-                .filter { it.cltvExpiry.toLong() == lockTime && ripemd160(it.paymentHash).toByteVector() == paymentHash160 }
-                .sortedWith(compareBy({ it.amountMsat.toLong() }, { it.id }))
+        private fun Transaction.isHtlcTimeout(localCommitPublished: LocalCommitPublished): Boolean {
+            return txIn.filter {
+                when (localCommitPublished.htlcTxs[it.outPoint]) {
+                    is HtlcTimeoutTx -> true
+                    else -> false
+                }
+            }.map { it.witness }.mapNotNull(extractPaymentHashFromHtlcTimeout()).isNotEmpty()
+        }
 
-            val matchingTxs = timeoutTxs
-                .filter { t -> t.lockTime == t.lockTime && t.txIn.map { it.witness }.map(extractPaymentHash).contains(paymentHash160) }
-                .sortedWith(compareBy({ t -> t.txOut.map { it.amount.sat }.sum() }, { it.txid.toHex() }))
+        private fun Transaction.isHtlcSuccess(localCommitPublished: LocalCommitPublished): Boolean {
+            return txIn.filter {
+                when (localCommitPublished.htlcTxs[it.outPoint]) {
+                    is HtlcSuccessTx -> true
+                    else -> false
+                }
+            }.map { it.witness }.mapNotNull(extractPreimageFromHtlcSuccess()).isNotEmpty()
+        }
 
-            if (matchingTxs.size != matchingHtlcs.size) {
-                logger.error { "some htlcs don't have a corresponding timeout transaction: tx=$this, htlcs=${matchingHtlcs.map { it.id }.joinToString()}, timeout-txs=${matchingTxs.joinToString()}" }
-            }
+        private fun Transaction.isClaimHtlcTimeout(remoteCommitPublished: RemoteCommitPublished): Boolean {
+            return txIn.filter {
+                when (remoteCommitPublished.claimHtlcTxs[it.outPoint]) {
+                    is ClaimHtlcTimeoutTx -> true
+                    else -> false
+                }
+            }.map { it.witness }.mapNotNull(extractPaymentHashFromClaimHtlcTimeout()).isNotEmpty()
+        }
 
-            return matchingHtlcs.zip(matchingTxs).firstOrNull { (_, timeoutTx) -> timeoutTx.txid == txid }?.first
+        private fun Transaction.isClaimHtlcSuccess(remoteCommitPublished: RemoteCommitPublished): Boolean {
+            return txIn.filter {
+                when (remoteCommitPublished.claimHtlcTxs[it.outPoint]) {
+                    is ClaimHtlcSuccessTx -> true
+                    else -> false
+                }
+            }.map { it.witness }.mapNotNull(extractPreimageFromClaimHtlcSuccess()).isNotEmpty()
         }
 
         /**
@@ -865,23 +891,30 @@ object Helpers {
          */
         fun LocalCommit.timedOutHtlcs(localCommitPublished: LocalCommitPublished, localDustLimit: Satoshi, tx: Transaction): Set<UpdateAddHtlc> {
             val untrimmedHtlcs = Transactions.trimOfferedHtlcs(localDustLimit, spec).map { it.add }
-            return if (tx.txid == publishableTxs.commitTx.tx.txid) {
-                // the tx is a commitment tx, we can immediately fail all dust htlcs (they don't have an output in the tx)
-                (spec.htlcs.outgoings() - untrimmedHtlcs).toSet()
-            } else {
-                // maybe this is a timeout tx, in that case we can resolve and fail the corresponding htlc
-                tx.txIn
-                    .map { it.witness }
-                    .mapNotNull(Scripts.extractPaymentHashFromHtlcTimeout())
-                    .mapNotNull { paymentHash160 ->
-                        logger.info { ("extracted paymentHash160=$paymentHash160 and expiry=${tx.lockTime} from tx=$tx (htlc-timeout)") }
-                        tx.findTimedOutHtlc(
-                            paymentHash160,
-                            untrimmedHtlcs,
-                            localCommitPublished.htlcTimeoutTxs,
-                            Scripts.extractPaymentHashFromHtlcTimeout()
-                        )
+            return when {
+                tx.txid == publishableTxs.commitTx.tx.txid -> {
+                    // the tx is a commitment tx, we can immediately fail all dust htlcs (they don't have an output in the tx)
+                    (spec.htlcs.outgoings() - untrimmedHtlcs).toSet()
+                }
+                tx.isHtlcTimeout(localCommitPublished) -> {
+                    // maybe this is a timeout tx, in that case we can resolve and fail the corresponding htlc
+                    tx.txIn.mapNotNull { txIn ->
+                        when (val htlcTx = localCommitPublished.htlcTxs[txIn.outPoint]) {
+                            is HtlcTimeoutTx -> when (val htlc = untrimmedHtlcs.find { it.id == htlcTx.htlcId }) {
+                                null -> {
+                                    logger.error { "could not find htlc #${htlcTx.htlcId} for htlc-timeout tx=$tx" }
+                                    null
+                                }
+                                else -> {
+                                    logger.info { "htlc-timeout tx for htlc #${htlc.id} paymentHash=${htlc.paymentHash} expiry=${tx.lockTime} has been confirmed (tx=$tx)" }
+                                    htlc
+                                }
+                            }
+                            else -> null
+                        }
                     }.toSet()
+                }
+                else -> emptySet()
             }
         }
 
@@ -894,23 +927,30 @@ object Helpers {
          */
         fun RemoteCommit.timedOutHtlcs(remoteCommitPublished: RemoteCommitPublished, remoteDustLimit: Satoshi, tx: Transaction): Set<UpdateAddHtlc> {
             val untrimmedHtlcs = Transactions.trimReceivedHtlcs(remoteDustLimit, spec).map { it.add }
-            return if (tx.txid == txid) {
-                // the tx is a commitment tx, we can immediately fail all dust htlcs (they don't have an output in the tx)
-                (spec.htlcs.incomings() - untrimmedHtlcs).toSet()
-            } else {
-                // maybe this is a timeout tx, in that case we can resolve and fail the corresponding htlc
-                tx.txIn
-                    .map { it.witness }
-                    .mapNotNull(Scripts.extractPaymentHashFromClaimHtlcTimeout())
-                    .mapNotNull { paymentHash160 ->
-                        logger.info { "extracted paymentHash160=$paymentHash160 and expiry=${tx.lockTime} from tx=$tx (claim-htlc-timeout)" }
-                        tx.findTimedOutHtlc(
-                            paymentHash160,
-                            untrimmedHtlcs,
-                            remoteCommitPublished.claimHtlcTimeoutTxs,
-                            Scripts.extractPaymentHashFromClaimHtlcTimeout()
-                        )
+            return when {
+                tx.txid == txid -> {
+                    // the tx is a commitment tx, we can immediately fail all dust htlcs (they don't have an output in the tx)
+                    (spec.htlcs.incomings() - untrimmedHtlcs).toSet()
+                }
+                tx.isClaimHtlcTimeout(remoteCommitPublished) -> {
+                    // maybe this is a timeout tx, in that case we can resolve and fail the corresponding htlc
+                    tx.txIn.mapNotNull { txIn ->
+                        when (val htlcTx = remoteCommitPublished.claimHtlcTxs[txIn.outPoint]) {
+                            is ClaimHtlcTimeoutTx -> when (val htlc = untrimmedHtlcs.find { it.id == htlcTx.htlcId }) {
+                                null -> {
+                                    logger.error { "could not find htlc #${htlcTx.htlcId} for claim-htlc-timeout tx=$tx" }
+                                    null
+                                }
+                                else -> {
+                                    logger.info { "claim-htlc-timeout tx for htlc #${htlc.id} paymentHash=${htlc.paymentHash} expiry=${tx.lockTime} has been confirmed (tx=$tx)" }
+                                    htlc
+                                }
+                            }
+                            else -> null
+                        }
                     }.toSet()
+                }
+                else -> emptySet()
             }
         }
 
@@ -964,7 +1004,7 @@ object Helpers {
          * @param irrevocablySpent a map of known spent outpoints
          * @return true if we know for sure that the utxos consumed by the tx have already irrevocably been spent, false otherwise
          */
-        fun Transaction.inputsAlreadySpent(irrevocablySpent: Map<OutPoint, ByteVector32>): Boolean {
+        fun Transaction.inputsAlreadySpent(irrevocablySpent: Map<OutPoint, Transaction>): Boolean {
             // NB: some transactions may have multiple inputs (e.g. htlc txs)
             val outPoints = txIn.map { it.outPoint }
             return outPoints.any { irrevocablySpent.contains(it) }

--- a/src/commonMain/kotlin/fr/acinq/eclair/transactions/Transactions.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/transactions/Transactions.kt
@@ -121,7 +121,7 @@ object Transactions {
 
         @Serializable
         data class ClosingTx(override val input: InputInfo, @Serializable(with = TransactionKSerializer::class) override val tx: Transaction, val toLocalIndex: Int?) : TransactionWithInputInfo() {
-            val toLocalOutput: TxOut? get() = toLocalIndex?.let { tx.txOut.getOrNull(it) }
+            val toLocalOutput: TxOut? get() = toLocalIndex?.let { tx.txOut[it] }
         }
     }
 

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/ChannelTypesTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/ChannelTypesTestsCommon.kt
@@ -5,7 +5,17 @@ import fr.acinq.eclair.Eclair.randomBytes32
 import fr.acinq.eclair.Eclair.randomKey
 import fr.acinq.eclair.blockchain.WatchConfirmed
 import fr.acinq.eclair.blockchain.WatchSpent
+import fr.acinq.eclair.channel.TestsHelper.claimHtlcSuccessTxs
+import fr.acinq.eclair.channel.TestsHelper.claimHtlcTimeoutTxs
+import fr.acinq.eclair.channel.TestsHelper.htlcSuccessTxs
+import fr.acinq.eclair.channel.TestsHelper.htlcTimeoutTxs
 import fr.acinq.eclair.tests.utils.EclairTestSuite
+import fr.acinq.eclair.transactions.Transactions.InputInfo
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.*
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcSuccessTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.ClaimHtlcTx.ClaimHtlcTimeoutTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcSuccessTx
+import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo.HtlcTx.HtlcTimeoutTx
 import fr.acinq.eclair.utils.sat
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,227 +33,231 @@ class ChannelTypesTestsCommon : EclairTestSuite() {
     @Test
     fun `local commit published`() {
         val (lcp, _, _) = createClosingTransactions()
-        assertFalse { lcp.isConfirmed() }
-        assertFalse { lcp.isDone() }
+        assertFalse(lcp.isConfirmed())
+        assertFalse(lcp.isDone())
 
         run {
             val actions = lcp.doPublish(randomBytes32(), 6)
             // We use watch-confirmed on the outputs only us can claim.
             val watchConfirmed = actions.findWatches<WatchConfirmed>().map { it.txId }.toSet()
-            assertEquals(watchConfirmed, setOf(lcp.commitTx.txid, lcp.claimMainDelayedOutputTx!!.txid) + lcp.claimHtlcDelayedTxs.map { it.txid }.toSet())
+            assertEquals(watchConfirmed, setOf(lcp.commitTx.txid, lcp.claimMainDelayedOutputTx!!.tx.txid) + lcp.claimHtlcDelayedTxs.map { it.tx.txid }.toSet())
             // We use watch-spent on the outputs both parties can claim (htlc outputs).
             val watchSpent = actions.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet()
             assertEquals(watchSpent, listOf(2L, 3L, 4L, 5L).map { OutPoint(lcp.commitTx.txid, it) }.toSet())
-            val txs = actions.findTxs()
-            assertEquals(txs, listOf(lcp.commitTx, lcp.claimMainDelayedOutputTx!!) + lcp.htlcSuccessTxs + lcp.htlcTimeoutTxs + lcp.claimHtlcDelayedTxs)
+            val txs = actions.findTxs().toSet()
+            assertEquals(txs, setOf(lcp.commitTx, lcp.claimMainDelayedOutputTx!!.tx) + lcp.htlcTxs.values.filterNotNull().map { it.tx } + lcp.claimHtlcDelayedTxs.map { it.tx }.toSet())
         }
 
         // Commit tx has been confirmed.
         val lcp1 = lcp.update(lcp.commitTx)
-        assertTrue { lcp1.irrevocablySpent.isNotEmpty() }
-        assertTrue { lcp1.isConfirmed() }
-        assertFalse { lcp1.isDone() }
+        assertTrue(lcp1.irrevocablySpent.isNotEmpty())
+        assertTrue(lcp1.isConfirmed())
+        assertFalse(lcp1.isDone())
 
         // Main output has been confirmed.
-        val lcp2 = lcp1.update(lcp.claimMainDelayedOutputTx!!)
-        assertTrue { lcp2.isConfirmed() }
-        assertFalse { lcp2.isDone() }
+        val lcp2 = lcp1.update(lcp.claimMainDelayedOutputTx!!.tx)
+        assertTrue(lcp2.isConfirmed())
+        assertFalse(lcp2.isDone())
 
         // Our htlc-success txs and their 3rd-stage claim txs have been confirmed.
-        val lcp3 = lcp2.update(lcp.htlcSuccessTxs[0]).update(lcp.claimHtlcDelayedTxs[0]).update(lcp.htlcSuccessTxs[1]).update(lcp.claimHtlcDelayedTxs[1])
-        assertTrue { lcp3.isConfirmed() }
-        assertFalse { lcp3.isDone() }
+        val lcp3 = lcp2.update(lcp.htlcSuccessTxs().first().tx).update(lcp.claimHtlcDelayedTxs[0].tx).update(lcp.htlcSuccessTxs().last().tx).update(lcp.claimHtlcDelayedTxs[1].tx)
+        assertTrue(lcp3.isConfirmed())
+        assertFalse(lcp3.isDone())
 
         run {
             val actions = lcp3.doPublish(randomBytes32(), 3)
             // The only remaining transactions to watch are the 3rd-stage txs for the htlc-timeout.
             val watchConfirmed = actions.findWatches<WatchConfirmed>().map { it.txId }.toSet()
-            assertEquals(watchConfirmed, lcp.claimHtlcDelayedTxs.drop(2).map { it.txid }.toSet())
+            assertEquals(watchConfirmed, lcp.claimHtlcDelayedTxs.drop(2).map { it.tx.txid }.toSet())
             // We still watch the remaining unclaimed htlc outputs.
             val watchSpent = actions.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet()
             assertEquals(watchSpent, listOf(4L, 5L).map { OutPoint(lcp.commitTx.txid, it) }.toSet())
             val txs = actions.findTxs()
-            assertEquals(txs, lcp.htlcTimeoutTxs + lcp.claimHtlcDelayedTxs.drop(2))
+            assertEquals(txs, lcp.htlcTimeoutTxs().map { it.tx } + lcp.claimHtlcDelayedTxs.drop(2).map { it.tx })
         }
 
         // Scenario 1: our htlc-timeout txs and their 3rd-stage claim txs have been confirmed.
         run {
-            val lcp4a = lcp3.update(lcp.htlcTimeoutTxs[0]).update(lcp.claimHtlcDelayedTxs[2]).update(lcp.htlcTimeoutTxs[1])
-            assertTrue { lcp4a.isConfirmed() }
-            assertFalse { lcp4a.isDone() }
+            val lcp4a = lcp3.update(lcp.htlcTimeoutTxs().first().tx).update(lcp.claimHtlcDelayedTxs[2].tx).update(lcp.htlcTimeoutTxs().last().tx)
+            assertTrue(lcp4a.isConfirmed())
+            assertFalse(lcp4a.isDone())
 
-            val lcp4b = lcp4a.update(lcp.claimHtlcDelayedTxs[3])
-            assertTrue { lcp4b.isConfirmed() }
-            assertTrue { lcp4b.isDone() }
+            val lcp4b = lcp4a.update(lcp.claimHtlcDelayedTxs[3].tx)
+            assertTrue(lcp4b.isConfirmed())
+            assertTrue(lcp4b.isDone())
         }
 
         // Scenario 2: they claim the htlcs we sent before our htlc-timeout.
         run {
-            val claimHtlcSuccess1 = lcp.htlcTimeoutTxs[0].copy(txOut = listOf(TxOut(3_000.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
+            val claimHtlcSuccess1 = lcp.htlcTimeoutTxs().first().tx.copy(txOut = listOf(TxOut(3_000.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
             val lcp4a = lcp3.update(claimHtlcSuccess1)
-            assertTrue { lcp4a.isConfirmed() }
-            assertFalse { lcp4a.isDone() }
+            assertTrue(lcp4a.isConfirmed())
+            assertFalse(lcp4a.isDone())
 
-            val claimHtlcSuccess2 = lcp.htlcTimeoutTxs[1].copy(txOut = listOf(TxOut(3_500.sat, ByteVector.empty), TxOut(3_100.sat, ByteVector.empty)))
+            val claimHtlcSuccess2 = lcp.htlcTimeoutTxs().last().tx.copy(txOut = listOf(TxOut(3_500.sat, ByteVector.empty), TxOut(3_100.sat, ByteVector.empty)))
             val lcp4b = lcp4a.update(claimHtlcSuccess2)
-            assertTrue { lcp4b.isConfirmed() }
-            assertTrue { lcp4b.isDone() }
+            assertTrue(lcp4b.isConfirmed())
+            assertTrue(lcp4b.isDone())
         }
     }
 
     @Test
     fun `remote commit published`() {
         val (_, rcp, _) = createClosingTransactions()
-        assertFalse { rcp.isConfirmed() }
-        assertFalse { rcp.isDone() }
+        assertFalse(rcp.isConfirmed())
+        assertFalse(rcp.isDone())
 
         run {
             val actions = rcp.doPublish(randomBytes32(), 6)
             // We use watch-confirmed on the outputs only us can claim.
             val watchConfirmed = actions.findWatches<WatchConfirmed>().map { it.txId }.toSet()
-            assertEquals(watchConfirmed, setOf(rcp.commitTx.txid, rcp.claimMainOutputTx!!.txid))
+            assertEquals(watchConfirmed, setOf(rcp.commitTx.txid, rcp.claimMainOutputTx!!.tx.txid))
             // We use watch-spent on the outputs both parties can claim (htlc outputs).
             val watchSpent = actions.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet()
             assertEquals(watchSpent, listOf(2L, 3L, 4L, 5L).map { OutPoint(rcp.commitTx.txid, it) }.toSet())
             val txs = actions.findTxs().toSet()
-            assertEquals(txs, setOf(rcp.claimMainOutputTx!!) + rcp.claimHtlcSuccessTxs.toSet() + rcp.claimHtlcTimeoutTxs.toSet())
+            assertEquals(txs, setOf(rcp.claimMainOutputTx!!.tx) + rcp.claimHtlcTxs.values.filterNotNull().map { it.tx }.toSet())
         }
 
         // Commit tx has been confirmed.
         val rcp1 = rcp.update(rcp.commitTx)
-        assertTrue { rcp1.irrevocablySpent.isNotEmpty() }
-        assertTrue { rcp1.isConfirmed() }
-        assertFalse { rcp1.isDone() }
+        assertTrue(rcp1.irrevocablySpent.isNotEmpty())
+        assertTrue(rcp1.isConfirmed())
+        assertFalse(rcp1.isDone())
 
         // Main output has been confirmed.
-        val rcp2 = rcp1.update(rcp.claimMainOutputTx!!)
-        assertTrue { rcp2.isConfirmed() }
-        assertFalse { rcp2.isDone() }
+        val rcp2 = rcp1.update(rcp.claimMainOutputTx!!.tx)
+        assertTrue(rcp2.isConfirmed())
+        assertFalse(rcp2.isDone())
 
         // One of our claim-htlc-success and claim-htlc-timeout has been confirmed.
-        val rcp3 = rcp2.update(rcp.claimHtlcSuccessTxs[0]).update(rcp.claimHtlcTimeoutTxs[0])
-        assertTrue { rcp3.isConfirmed() }
-        assertFalse { rcp3.isDone() }
+        val rcp3 = rcp2.update(rcp.claimHtlcSuccessTxs().first().tx).update(rcp.claimHtlcTimeoutTxs().first().tx)
+        assertTrue(rcp3.isConfirmed())
+        assertFalse(rcp3.isDone())
 
         run {
             val actions = rcp3.doPublish(randomBytes32(), 3)
             // Our main output has been confirmed already.
-            assertTrue { actions.findWatches<WatchConfirmed>().isEmpty() }
+            assertTrue(actions.findWatches<WatchConfirmed>().isEmpty())
             // We still watch the remaining unclaimed htlc outputs.
             val watchSpent = actions.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet()
             assertEquals(watchSpent, listOf(3L, 5L).map { OutPoint(rcp.commitTx.txid, it) }.toSet())
             val txs = actions.findTxs().toSet()
-            assertEquals(txs, setOf(rcp.claimHtlcSuccessTxs[1], rcp.claimHtlcTimeoutTxs[1]))
+            assertEquals(txs, setOf(rcp.claimHtlcSuccessTxs().last().tx, rcp.claimHtlcTimeoutTxs().last().tx))
         }
 
         // Scenario 1: our remaining claim-htlc txs have been confirmed.
         run {
-            val rcp4a = rcp3.update(rcp.claimHtlcSuccessTxs[1])
-            assertTrue { rcp4a.isConfirmed() }
-            assertFalse { rcp4a.isDone() }
+            val rcp4a = rcp3.update(rcp.claimHtlcSuccessTxs().last().tx)
+            assertTrue(rcp4a.isConfirmed())
+            assertFalse(rcp4a.isDone())
 
-            val rcp4b = rcp4a.update(rcp.claimHtlcTimeoutTxs[1])
-            assertTrue { rcp4b.isConfirmed() }
-            assertTrue { rcp4b.isDone() }
+            val rcp4b = rcp4a.update(rcp.claimHtlcTimeoutTxs().last().tx)
+            assertTrue(rcp4b.isConfirmed())
+            assertTrue(rcp4b.isDone())
         }
 
         // Scenario 2: they claim the remaining htlc outputs.
         run {
-            val htlcSuccess = rcp.claimHtlcSuccessTxs[1].copy(txOut = listOf(TxOut(3_000.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
+            val htlcSuccess = rcp.claimHtlcSuccessTxs().last().tx.copy(txOut = listOf(TxOut(3_000.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
             val rcp4a = rcp3.update(htlcSuccess)
-            assertTrue { rcp4a.isConfirmed() }
-            assertFalse { rcp4a.isDone() }
+            assertTrue(rcp4a.isConfirmed())
+            assertFalse(rcp4a.isDone())
 
-            val htlcTimeout = rcp.claimHtlcTimeoutTxs[1].copy(txOut = listOf(TxOut(3_500.sat, ByteVector.empty), TxOut(3_100.sat, ByteVector.empty)))
+            val htlcTimeout = rcp.claimHtlcTimeoutTxs().last().tx.copy(txOut = listOf(TxOut(3_500.sat, ByteVector.empty), TxOut(3_100.sat, ByteVector.empty)))
             val rcp4b = rcp4a.update(htlcTimeout)
-            assertTrue { rcp4b.isConfirmed() }
-            assertTrue { rcp4b.isDone() }
+            assertTrue(rcp4b.isConfirmed())
+            assertTrue(rcp4b.isDone())
         }
     }
 
     @Test
     fun `revoked commit published`() {
         val (_, _, rvk) = createClosingTransactions()
-        assertFalse { rvk.isDone() }
+        assertFalse(rvk.isDone())
 
         run {
             val actions = rvk.doPublish(randomBytes32(), 6)
             // We use watch-confirmed on the outputs only us can claim.
             val watchConfirmed = actions.findWatches<WatchConfirmed>().map { it.txId }.toSet()
-            assertEquals(watchConfirmed, setOf(rvk.commitTx.txid, rvk.claimMainOutputTx!!.txid))
+            assertEquals(watchConfirmed, setOf(rvk.commitTx.txid, rvk.claimMainOutputTx!!.tx.txid))
             // We use watch-spent on the outputs both parties can claim (htlc outputs and the remote main output).
             val watchSpent = actions.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet()
             assertEquals(watchSpent, listOf(1L, 2L, 3L, 4L, 5L).map { OutPoint(rvk.commitTx.txid, it) }.toSet())
             val txs = actions.findTxs().toSet()
-            assertEquals(txs, setOf(rvk.claimMainOutputTx!!, rvk.mainPenaltyTx!!) + rvk.htlcPenaltyTxs.toSet())
+            assertEquals(txs, setOf(rvk.claimMainOutputTx!!.tx, rvk.mainPenaltyTx!!.tx) + rvk.htlcPenaltyTxs.map { it.tx }.toSet())
         }
 
         // Commit tx has been confirmed.
         val rvk1 = rvk.update(rvk.commitTx)
-        assertTrue { rvk1.irrevocablySpent.isNotEmpty() }
-        assertFalse { rvk1.isDone() }
+        assertTrue(rvk1.irrevocablySpent.isNotEmpty())
+        assertFalse(rvk1.isDone())
 
         // Main output has been confirmed.
-        val rvk2 = rvk1.update(rvk.claimMainOutputTx!!)
-        assertFalse { rvk2.isDone() }
+        val rvk2 = rvk1.update(rvk.claimMainOutputTx!!.tx)
+        assertFalse(rvk2.isDone())
 
         // Two of our htlc penalty txs have been confirmed.
-        val rvk3 = rvk2.update(rvk.htlcPenaltyTxs[0]).update(rvk.htlcPenaltyTxs[1])
-        assertFalse { rvk3.isDone() }
+        val rvk3 = rvk2.update(rvk.htlcPenaltyTxs[0].tx).update(rvk.htlcPenaltyTxs[1].tx)
+        assertFalse(rvk3.isDone())
 
         run {
             val actions = rvk3.doPublish(randomBytes32(), 3)
             // Our main output has been confirmed already.
-            assertTrue { actions.findWatches<WatchConfirmed>().isEmpty() }
+            assertTrue(actions.findWatches<WatchConfirmed>().isEmpty())
             // We still watch the remaining unclaimed outputs (htlc and remote main output).
             val watchSpent = actions.findWatches<WatchSpent>().map { OutPoint(it.txId, it.outputIndex.toLong()) }.toSet()
             assertEquals(watchSpent, listOf(1L, 4L, 5L).map { OutPoint(rvk.commitTx.txid, it) }.toSet())
             val txs = actions.findTxs().toSet()
-            assertEquals(txs, setOf(rvk.mainPenaltyTx!!, rvk.htlcPenaltyTxs[2], rvk.htlcPenaltyTxs[3]))
+            assertEquals(txs, setOf(rvk.mainPenaltyTx!!.tx, rvk.htlcPenaltyTxs[2].tx, rvk.htlcPenaltyTxs[3].tx))
         }
 
         // Scenario 1: the remaining penalty txs have been confirmed.
         run {
-            val rvk4a = rvk3.update(rvk.htlcPenaltyTxs[2]).update(rvk.htlcPenaltyTxs[3])
-            assertFalse { rvk4a.isDone() }
+            val rvk4a = rvk3.update(rvk.htlcPenaltyTxs[2].tx).update(rvk.htlcPenaltyTxs[3].tx)
+            assertFalse(rvk4a.isDone())
 
-            val rvk4b = rvk4a.update(rvk.mainPenaltyTx!!)
-            assertTrue { rvk4b.isDone() }
+            val rvk4b = rvk4a.update(rvk.mainPenaltyTx!!.tx)
+            assertTrue(rvk4b.isDone())
         }
 
         // Scenario 2: they claim the remaining outputs.
         run {
-            val remoteMainOutput = rvk.mainPenaltyTx!!.copy(txOut = listOf(TxOut(35_000.sat, ByteVector.empty)))
+            val remoteMainOutput = rvk.mainPenaltyTx!!.tx.copy(txOut = listOf(TxOut(35_000.sat, ByteVector.empty)))
             val rvk4a = rvk3.update(remoteMainOutput)
-            assertFalse { rvk4a.isDone() }
+            assertFalse(rvk4a.isDone())
 
-            val htlcSuccess = rvk.htlcPenaltyTxs[2].copy(txOut = listOf(TxOut(3_000.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
-            val htlcTimeout = rvk.htlcPenaltyTxs[3].copy(txOut = listOf(TxOut(3_500.sat, ByteVector.empty), TxOut(3_100.sat, ByteVector.empty)))
+            val htlcSuccess = rvk.htlcPenaltyTxs[2].tx.copy(txOut = listOf(TxOut(3_000.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
+            val htlcTimeout = rvk.htlcPenaltyTxs[3].tx.copy(txOut = listOf(TxOut(3_500.sat, ByteVector.empty), TxOut(3_100.sat, ByteVector.empty)))
             // When Bob claims these outputs, the channel should call Helpers.claimRevokedHtlcTxOutputs to punish them by claiming the output of their htlc tx.
             val rvk4b = rvk4a.update(htlcSuccess).update(htlcTimeout).copy(
                 claimHtlcDelayedPenaltyTxs = listOf(
                     Transaction(2, listOf(TxIn(OutPoint(htlcSuccess, 0), 0)), listOf(TxOut(5_000.sat, ByteVector.empty)), 0),
                     Transaction(2, listOf(TxIn(OutPoint(htlcTimeout, 0), 0)), listOf(TxOut(6_000.sat, ByteVector.empty)), 0)
-                )
+                ).map { ClaimHtlcDelayedOutputPenaltyTx(txInput(it), it) }
             )
-            assertFalse { rvk4b.isDone() }
+            assertFalse(rvk4b.isDone())
 
             val actions = rvk4b.doPublish(randomBytes32(), 3)
-            assertTrue { actions.findWatches<WatchConfirmed>().isEmpty() }
+            assertTrue(actions.findWatches<WatchConfirmed>().isEmpty())
             // NB: the channel, after calling Helpers.claimRevokedHtlcTxOutputs, will put a watch-spent on the htlc-txs.
-            assertTrue { actions.findWatches<WatchSpent>().isEmpty() }
-            assertEquals(actions.findTxs().toSet(), rvk4b.claimHtlcDelayedPenaltyTxs.toSet())
+            assertTrue(actions.findWatches<WatchSpent>().isEmpty())
+            assertEquals(actions.findTxs().toSet(), rvk4b.claimHtlcDelayedPenaltyTxs.map { it.tx }.toSet())
 
             // We claim one of the remaining outputs, they claim the other.
-            val rvk5a = rvk4b.update(rvk4b.claimHtlcDelayedPenaltyTxs[0])
-            assertFalse { rvk5a.isDone() }
-            val theyClaimHtlcTimeout = rvk4b.claimHtlcDelayedPenaltyTxs[1].copy(txOut = listOf(TxOut(1_500.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
+            val rvk5a = rvk4b.update(rvk4b.claimHtlcDelayedPenaltyTxs[0].tx)
+            assertFalse(rvk5a.isDone())
+            val theyClaimHtlcTimeout = rvk4b.claimHtlcDelayedPenaltyTxs[1].tx.copy(txOut = listOf(TxOut(1_500.sat, ByteVector.empty), TxOut(2_500.sat, ByteVector.empty)))
             val rvk5b = rvk5a.update(theyClaimHtlcTimeout)
-            assertTrue { rvk5b.isDone() }
+            assertTrue(rvk5b.isDone())
         }
     }
 
     companion object {
+        private fun txInput(tx: Transaction): InputInfo {
+            return InputInfo(tx.txIn.first().outPoint, TxOut(0.sat, ByteVector.empty), ByteVector.empty)
+        }
+
         private fun createClosingTransactions(): Triple<LocalCommitPublished, RemoteCommitPublished, RevokedCommitPublished> {
             val commitTx = Transaction(
                 2,
@@ -265,20 +279,41 @@ class ChannelTypesTestsCommon : EclairTestSuite() {
             val htlcTimeout2 = Transaction(2, listOf(TxIn(OutPoint(commitTx, 5), 1)), listOf(TxOut(6_500.sat, ByteVector.empty)), 0)
 
             val localCommit = run {
+                val htlcTxs = mapOf(
+                    htlcSuccess1.txIn.first().outPoint to HtlcSuccessTx(txInput(htlcSuccess1), htlcSuccess1, randomBytes32(), 0),
+                    htlcSuccess2.txIn.first().outPoint to HtlcSuccessTx(txInput(htlcSuccess2), htlcSuccess2, randomBytes32(), 1),
+                    htlcTimeout1.txIn.first().outPoint to HtlcTimeoutTx(txInput(htlcTimeout1), htlcTimeout1, 0),
+                    htlcTimeout2.txIn.first().outPoint to HtlcTimeoutTx(txInput(htlcTimeout2), htlcTimeout2, 1),
+                )
                 val claimHtlcDelayedTxs = listOf(
                     Transaction(2, listOf(TxIn(OutPoint(htlcSuccess1, 0), 1)), listOf(TxOut(3_400.sat, ByteVector.empty)), 0),
                     Transaction(2, listOf(TxIn(OutPoint(htlcSuccess2, 0), 1)), listOf(TxOut(4_400.sat, ByteVector.empty)), 0),
                     Transaction(2, listOf(TxIn(OutPoint(htlcTimeout1, 0), 1)), listOf(TxOut(5_400.sat, ByteVector.empty)), 0),
                     Transaction(2, listOf(TxIn(OutPoint(htlcTimeout2, 0), 1)), listOf(TxOut(6_400.sat, ByteVector.empty)), 0),
-                )
-                LocalCommitPublished(commitTx, claimMainAlice, listOf(htlcSuccess1, htlcSuccess2), listOf(htlcTimeout1, htlcTimeout2), claimHtlcDelayedTxs)
+                ).map { ClaimLocalDelayedOutputTx(txInput(it), it) }
+                val claimMain = ClaimLocalDelayedOutputTx(txInput(claimMainAlice), claimMainAlice)
+                LocalCommitPublished(commitTx, claimMain, htlcTxs, claimHtlcDelayedTxs)
             }
 
-            val remoteCommit = RemoteCommitPublished(commitTx, claimMainAlice, listOf(htlcSuccess1, htlcSuccess2), listOf(htlcTimeout1, htlcTimeout2))
+            val remoteCommit = run {
+                val claimMain = ClaimRemoteCommitMainOutputTx.ClaimP2WPKHOutputTx(txInput(claimMainAlice), claimMainAlice)
+                val claimHtlcTxs = mapOf(
+                    htlcSuccess1.txIn.first().outPoint to ClaimHtlcSuccessTx(txInput(htlcSuccess1), htlcSuccess1, 0),
+                    htlcSuccess2.txIn.first().outPoint to ClaimHtlcSuccessTx(txInput(htlcSuccess2), htlcSuccess2, 1),
+                    htlcTimeout1.txIn.first().outPoint to ClaimHtlcTimeoutTx(txInput(htlcTimeout1), htlcTimeout1, 0),
+                    htlcTimeout2.txIn.first().outPoint to ClaimHtlcTimeoutTx(txInput(htlcTimeout2), htlcTimeout2, 1),
+                )
+                RemoteCommitPublished(commitTx, claimMain, claimHtlcTxs)
+            }
 
             val revokedCommit = run {
-                val mainPenalty = Transaction(2, listOf(TxIn(OutPoint(commitTx, 1), 0)), listOf(TxOut(39_500.sat, ByteVector.empty)), 0)
-                RevokedCommitPublished(commitTx, randomKey(), claimMainAlice, mainPenalty, listOf(htlcSuccess1, htlcSuccess2, htlcTimeout1, htlcTimeout2))
+                val mainPenalty = run {
+                    val tx = Transaction(2, listOf(TxIn(OutPoint(commitTx, 1), 0)), listOf(TxOut(39_500.sat, ByteVector.empty)), 0)
+                    MainPenaltyTx(txInput(tx), tx)
+                }
+                val claimMain = ClaimRemoteCommitMainOutputTx.ClaimP2WPKHOutputTx(txInput(claimMainAlice), claimMainAlice)
+                val htlcPenaltyTxs = listOf(htlcSuccess1, htlcSuccess2, htlcTimeout1, htlcTimeout2).map { HtlcPenaltyTx(txInput(it), it) }
+                RevokedCommitPublished(commitTx, randomKey(), claimMain, mainPenalty, htlcPenaltyTxs)
             }
 
             return Triple(localCommit, remoteCommit, revokedCommit)

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NegotiatingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/NegotiatingTestsCommon.kt
@@ -123,8 +123,8 @@ class NegotiatingTestsCommon : EclairTestSuite() {
         assertEquals(mutualCloseTxAlice, mutualCloseTxBob)
         assertEquals(actions.findWatches<WatchConfirmed>().map { it.event }, listOf(BITCOIN_TX_CONFIRMED(mutualCloseTxBob)))
         assertEquals(actions1.findWatches<WatchConfirmed>().map { it.event }, listOf(BITCOIN_TX_CONFIRMED(mutualCloseTxBob)))
-        assertEquals(bob1.mutualClosePublished, listOf(mutualCloseTxBob))
-        assertEquals(alice1.mutualClosePublished, listOf(mutualCloseTxBob))
+        assertEquals(bob1.mutualClosePublished.map { it.tx }, listOf(mutualCloseTxBob))
+        assertEquals(alice1.mutualClosePublished.map { it.tx }, listOf(mutualCloseTxBob))
     }
 
     @Test
@@ -155,11 +155,11 @@ class NegotiatingTestsCommon : EclairTestSuite() {
             aliceCloseSig1.feeSatoshis,
             aliceCloseSig1.signature
         ).right!!
-        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobClosingTx)))
+        val (alice2, actionsAlice2) = alice1.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bobClosingTx.tx)))
         assertTrue(alice2 is Closing)
         actionsAlice2.has<ChannelAction.Storage.StoreState>()
-        actionsAlice2.hasTx(bobClosingTx)
-        assertEquals(actionsAlice2.hasWatch<WatchConfirmed>().txId, bobClosingTx.txid)
+        actionsAlice2.hasTx(bobClosingTx.tx)
+        assertEquals(actionsAlice2.hasWatch<WatchConfirmed>().txId, bobClosingTx.tx.txid)
     }
 
     @Test
@@ -181,7 +181,7 @@ class NegotiatingTestsCommon : EclairTestSuite() {
 
     companion object {
         fun init(tweakFees: Boolean = false, pushMsat: MilliSatoshi = TestConstants.pushMsat): Triple<Negotiating, Negotiating, ClosingSigned> {
-            val (alice, bob) = TestsHelper.reachNormal(pushMsat = pushMsat)
+            val (alice, bob) = reachNormal(pushMsat = pushMsat)
             return mutualClose(alice, bob, tweakFees)
         }
 

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
@@ -1,7 +1,6 @@
 package fr.acinq.eclair.channel.states
 
 import fr.acinq.bitcoin.*
-import fr.acinq.bitcoin.Crypto.sha256
 import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.Eclair.randomBytes32
 import fr.acinq.eclair.Eclair.randomKey
@@ -11,6 +10,8 @@ import fr.acinq.eclair.blockchain.WatchEventSpent
 import fr.acinq.eclair.blockchain.WatchSpent
 import fr.acinq.eclair.channel.*
 import fr.acinq.eclair.channel.TestsHelper.addHtlc
+import fr.acinq.eclair.channel.TestsHelper.claimHtlcSuccessTxs
+import fr.acinq.eclair.channel.TestsHelper.claimHtlcTimeoutTxs
 import fr.acinq.eclair.channel.TestsHelper.crossSign
 import fr.acinq.eclair.channel.TestsHelper.fulfillHtlc
 import fr.acinq.eclair.channel.TestsHelper.makeCmdAdd
@@ -22,7 +23,6 @@ import fr.acinq.eclair.tests.utils.EclairTestSuite
 import fr.acinq.eclair.utils.Either
 import fr.acinq.eclair.utils.UUID
 import fr.acinq.eclair.utils.msat
-import fr.acinq.eclair.utils.toByteVector32
 import fr.acinq.eclair.wire.*
 import kotlin.test.*
 
@@ -381,8 +381,9 @@ class ShutdownTestsCommon : EclairTestSuite() {
         assertEquals(6, bobCommitTx.txOut.size) // 2 main outputs + 2 anchors + 2 pending htlcs
         val (_, remoteCommitPublished) = TestsHelper.remoteClose(bobCommitTx, alice)
         assertNotNull(remoteCommitPublished.claimMainOutputTx)
-        assertTrue(remoteCommitPublished.claimHtlcSuccessTxs.isEmpty())
-        assertEquals(2, remoteCommitPublished.claimHtlcTimeoutTxs.size)
+        assertEquals(2, remoteCommitPublished.claimHtlcTxs.size)
+        assertTrue(remoteCommitPublished.claimHtlcSuccessTxs().isEmpty())
+        assertEquals(2, remoteCommitPublished.claimHtlcTimeoutTxs().size)
     }
 
     @Test
@@ -410,8 +411,9 @@ class ShutdownTestsCommon : EclairTestSuite() {
         aliceActions1.has<ChannelAction.Storage.StoreState>()
         val rcp = alice1.nextRemoteCommitPublished!!
         assertNotNull(rcp.claimMainOutputTx)
-        assertTrue(rcp.claimHtlcSuccessTxs.isEmpty())
-        assertEquals(2, rcp.claimHtlcTimeoutTxs.size)
+        assertEquals(2, rcp.claimHtlcTxs.size)
+        assertTrue(rcp.claimHtlcSuccessTxs().isEmpty())
+        assertEquals(2, rcp.claimHtlcTimeoutTxs().size)
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ShutdownTestsCommon.kt
@@ -457,22 +457,20 @@ class ShutdownTestsCommon : EclairTestSuite() {
         assertEquals(actions, listOf(ChannelAction.ProcessCmdRes.NotExecuted(CMD_CLOSE(null), ClosingAlreadyInProgress(alice.channelId))))
     }
 
-    @Test
-    fun `recv Error`() {
-        val (alice, _) = init()
+    private fun testLocalForceClose(alice: ChannelState, actions: List<ChannelAction>) {
+        assertTrue(alice is Closing)
         val aliceCommitTx = alice.commitments.localCommit.publishableTxs.commitTx
-        val (alice1, actions) = alice.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
-        assertTrue(alice1 is Closing)
-        assertNotNull(alice1.localCommitPublished)
-        assertEquals(alice1.localCommitPublished!!.commitTx, aliceCommitTx.tx)
+        val lcp = alice.localCommitPublished
+        assertNotNull(lcp)
+        assertEquals(lcp.commitTx, aliceCommitTx.tx)
 
         val txs = actions.filterIsInstance<ChannelAction.Blockchain.PublishTx>().map { it.tx }
         assertEquals(6, txs.size)
         // alice has sent 2 htlcs so we expect 6 transactions:
         // - alice's current commit tx
         // - 1 tx to claim the main delayed output
-        // - 2 txes for each htlc
-        // - 2 txes for each delayed output of the claimed htlc
+        // - 2 txs for each htlc
+        // - 2 txs for each delayed output of the claimed htlc
         assertEquals(aliceCommitTx.tx, txs[0])
         assertEquals(aliceCommitTx.tx.txOut.size, 6) // 2 anchor outputs + 2 main output + 2 pending htlcs
         // the main delayed output spends the commitment transaction
@@ -486,16 +484,28 @@ class ShutdownTestsCommon : EclairTestSuite() {
         Transaction.correctlySpends(txs[4], txs[2], ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         Transaction.correctlySpends(txs[5], txs[3], ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-        assertEquals(
-            actions.findWatches<WatchConfirmed>().map { it.txId },
-            listOf(
-                txs[0].txid, // commit tx
-                txs[1].txid, // main delayed
-                txs[4].txid, // htlc-delayed
-                txs[5].txid, // htlc-delayed
-            )
+        val expectedWatchConfirmed = listOf(
+            txs[0].txid, // commit tx
+            txs[1].txid, // main delayed
+            txs[4].txid, // htlc-delayed
+            txs[5].txid, // htlc-delayed
         )
-        assertEquals(2, actions.findWatches<WatchSpent>().size)
+        assertEquals(actions.findWatches<WatchConfirmed>().map { it.txId }, expectedWatchConfirmed)
+        assertEquals(lcp.htlcTxs.keys, actions.findWatches<WatchSpent>().map { OutPoint(aliceCommitTx.tx, it.outputIndex.toLong()) }.toSet())
+    }
+
+    @Test
+    fun `recv CMD_FORCECLOSE`() {
+        val (alice, _) = init()
+        val (alice1, actions1) = alice.processEx(ChannelEvent.ExecuteCommand(CMD_FORCECLOSE))
+        testLocalForceClose(alice1, actions1)
+    }
+
+    @Test
+    fun `recv Error`() {
+        val (alice, _) = init()
+        val (alice1, actions1) = alice.processEx(ChannelEvent.MessageReceived(Error(ByteVector32.Zeroes, "oops")))
+        testLocalForceClose(alice1, actions1)
     }
 
     companion object {

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/SyncingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/SyncingTestsCommon.kt
@@ -17,7 +17,6 @@ import fr.acinq.eclair.wire.Error
 import fr.acinq.eclair.wire.Init
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SyncingTestsCommon : EclairTestSuite() {
@@ -56,7 +55,7 @@ class SyncingTestsCommon : EclairTestSuite() {
         claimTxs.forEach { Transaction.correctlySpends(it, revokedTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS) }
         val watches = actions.findWatches<WatchConfirmed>()
         // we watch the revoked tx and our "claim main output tx"
-        assertEquals(watches.map { it.txId }.toSet(), setOf(revokedTx.txid, bob1.revokedCommitPublished.first().claimMainOutputTx!!.txid))
+        assertEquals(watches.map { it.txId }.toSet(), setOf(revokedTx.txid, bob1.revokedCommitPublished.first().claimMainOutputTx!!.tx.txid))
     }
 
     @Test

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingConfirmedTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/WaitForFundingConfirmedTestsCommon.kt
@@ -60,12 +60,12 @@ class WaitForFundingConfirmedTestsCommon : EclairTestSuite() {
         val publishAsap = actions1.findTxs()
         assertEquals(2, publishAsap.size)
         assertEquals(commitTx.txid, publishAsap.first().txid)
-        assertEquals(claimDelayedOutputTx.txid, publishAsap.last().txid)
+        assertEquals(claimDelayedOutputTx.tx.txid, publishAsap.last().txid)
 
         assertEquals(2, actions1.findWatches<WatchConfirmed>().size)
         val watches = actions1.findWatches<WatchConfirmed>()
         assertEquals(commitTx.txid, watches.first().txId)
-        assertEquals(claimDelayedOutputTx.txid, watches.last().txId)
+        assertEquals(claimDelayedOutputTx.tx.txid, watches.last().txId)
     }
 
     @Test
@@ -90,12 +90,12 @@ class WaitForFundingConfirmedTestsCommon : EclairTestSuite() {
         val publishAsap = actions1.findTxs()
         assertEquals(2, publishAsap.size)
         assertEquals(commitTx.txid, publishAsap.first().txid)
-        assertEquals(claimDelayedOutputTx.txid, publishAsap.last().txid)
+        assertEquals(claimDelayedOutputTx.tx.txid, publishAsap.last().txid)
 
         assertEquals(2, actions1.findWatches<WatchConfirmed>().size)
         val watches = actions1.findWatches<WatchConfirmed>()
         assertEquals(commitTx.txid, watches.first().txId)
-        assertEquals(claimDelayedOutputTx.txid, watches.last().txId)
+        assertEquals(claimDelayedOutputTx.tx.txid, watches.last().txId)
     }
 
     @Test
@@ -107,7 +107,7 @@ class WaitForFundingConfirmedTestsCommon : EclairTestSuite() {
             val (bob1, actions1) = bob.processEx(ChannelEvent.WatchReceived(WatchEventSpent(bob.channelId, BITCOIN_FUNDING_SPENT, alice.commitments.localCommit.publishableTxs.commitTx.tx)))
             assertTrue(bob1 is Closing)
             assertNotNull(bob1.remoteCommitPublished)
-            actions1.hasTx(bob1.remoteCommitPublished!!.claimMainOutputTx!!)
+            actions1.hasTx(bob1.remoteCommitPublished!!.claimMainOutputTx!!.tx)
             assertEquals(2, actions1.findWatches<WatchConfirmed>().size) // commit tx + main output
         }
 
@@ -116,7 +116,7 @@ class WaitForFundingConfirmedTestsCommon : EclairTestSuite() {
             val (alice1, actions1) = alice.processEx(ChannelEvent.WatchReceived(WatchEventSpent(alice.channelId, BITCOIN_FUNDING_SPENT, bob.commitments.localCommit.publishableTxs.commitTx.tx)))
             assertTrue(alice1 is Closing)
             assertNotNull(alice1.remoteCommitPublished)
-            actions1.hasTx(alice1.remoteCommitPublished!!.claimMainOutputTx!!)
+            actions1.hasTx(alice1.remoteCommitPublished!!.claimMainOutputTx!!.tx)
             assertEquals(2, actions1.findWatches<WatchConfirmed>().size) // commit tx + main output
         }
     }
@@ -160,7 +160,7 @@ class WaitForFundingConfirmedTestsCommon : EclairTestSuite() {
             assertTrue(state1 is Closing)
             assertNotNull(state1.localCommitPublished)
             actions1.hasTx(state1.localCommitPublished!!.commitTx)
-            actions1.hasTx(state1.localCommitPublished!!.claimMainDelayedOutputTx!!)
+            actions1.hasTx(state1.localCommitPublished!!.claimMainDelayedOutputTx!!.tx)
             assertEquals(2, actions1.findWatches<WatchConfirmed>().size) // commit tx + main output
         }
     }

--- a/src/commonTest/kotlin/fr/acinq/eclair/transactions/TransactionsTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/transactions/TransactionsTestsCommon.kt
@@ -519,22 +519,22 @@ class TransactionsTestsCommon : EclairTestSuite() {
             val spec = CommitmentSpec(setOf(), feerate, 150_000_000.msat, 250_000_000.msat)
             val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = true, localDustLimit, 1000.sat, spec)
             assertEquals(2, closingTx.tx.txOut.size)
-            assertNotNull(closingTx.toLocalOutput)
+            assertNotNull(closingTx.toLocalIndex)
             assertEquals(localPubKeyScript.toByteVector(), closingTx.toLocalOutput!!.publicKeyScript)
             assertEquals(149_000.sat, closingTx.toLocalOutput!!.amount) // funder pays the fee
-            val toRemoteIndex = (closingTx.toLocalOutput!!.index + 1) % 2
-            assertEquals(250_000.sat, closingTx.tx.txOut[toRemoteIndex.toInt()].amount)
+            val toRemoteIndex = (closingTx.toLocalIndex!! + 1) % 2
+            assertEquals(250_000.sat, closingTx.tx.txOut[toRemoteIndex].amount)
         }
         run {
             // Same amounts, both outputs untrimmed, local is fundee:
             val spec = CommitmentSpec(setOf(), feerate, 150_000_000.msat, 150_000_000.msat)
             val closingTx = makeClosingTx(commitInput, localPubKeyScript, remotePubKeyScript, localIsFunder = false, localDustLimit, 1000.sat, spec)
             assertEquals(2, closingTx.tx.txOut.size)
-            assertNotNull(closingTx.toLocalOutput)
+            assertNotNull(closingTx.toLocalIndex)
             assertEquals(localPubKeyScript.toByteVector(), closingTx.toLocalOutput!!.publicKeyScript)
             assertEquals(150_000.sat, closingTx.toLocalOutput!!.amount)
-            val toRemoteIndex = (closingTx.toLocalOutput!!.index + 1) % 2
-            assertEquals(149_000.sat, closingTx.tx.txOut[toRemoteIndex.toInt()].amount)
+            val toRemoteIndex = (closingTx.toLocalIndex!! + 1) % 2
+            assertEquals(149_000.sat, closingTx.tx.txOut[toRemoteIndex].amount)
         }
         run {
             // Their output is trimmed:
@@ -544,7 +544,7 @@ class TransactionsTestsCommon : EclairTestSuite() {
             assertNotNull(closingTx.toLocalOutput)
             assertEquals(localPubKeyScript.toByteVector(), closingTx.toLocalOutput!!.publicKeyScript)
             assertEquals(150_000.sat, closingTx.toLocalOutput!!.amount)
-            assertEquals(0, closingTx.toLocalOutput!!.index)
+            assertEquals(0, closingTx.toLocalIndex!!)
         }
         run {
             // Our output is trimmed:


### PR DESCRIPTION
Re-work the `CommitPublished` types to work better with anchor outputs.
We previously stored the txs spending utxos that we could claim: this doesn't make sense anymore if these txs may be RBF-ed, because the final tx will be different from the initial one.

We instead track what `OutPoint`s we can claim, and the information necessary to claim them.

We also add information on mutual close txs to immediately identify our output and its amount: this makes auditing how much sats we'll get back much easier for wallets.

@robbiehanson you may be interested in these changes for #228, in particular the new field added to `ClosingTx`.
Now that we use `TransactionWithInputInfo` you directly have a `fee` field on each transaction that is part of a force-close.

It would be great to get this PR in before we do a release, so that we don't have to care about backwards-compatibility!

The first commit contains the business logic changes and fixes to the existing tests. I'll add a few new tests in a separate commit.