### PR TITLE
Handle swap-in storage

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
@@ -32,7 +32,7 @@ class InMemoryPaymentsDb : PaymentsDb {
     }
 
     override suspend fun addAndReceivePayment(preimage: ByteVector32, origin: IncomingPayment.Origin, amount: MilliSatoshi, receivedWith: IncomingPayment.ReceivedWith, createdAt: Long, receivedAt: Long) {
-        val paymentHash = Crypto.sha256(preimage).toByteVector32()
+        val paymentHash = preimage.sha256()
         incoming[paymentHash] = IncomingPayment(preimage, origin, IncomingPayment.Received(amount, receivedWith, receivedAt), createdAt)
     }
 

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
@@ -31,6 +31,11 @@ class InMemoryPaymentsDb : PaymentsDb {
         }
     }
 
+    override suspend fun addAndReceivePayment(preimage: ByteVector32, origin: IncomingPayment.Origin, amount: MilliSatoshi, receivedWith: IncomingPayment.ReceivedWith, createdAt: Long, receivedAt: Long) {
+        val paymentHash = Crypto.sha256(preimage).toByteVector32()
+        incoming[paymentHash] = IncomingPayment(preimage, origin, IncomingPayment.Received(amount, receivedWith, receivedAt), createdAt)
+    }
+
     override suspend fun listReceivedPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter>): List<IncomingPayment> =
         incoming.values
             .asSequence()

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -29,6 +29,9 @@ interface IncomingPaymentsDb {
      */
     suspend fun receivePayment(paymentHash: ByteVector32, amount: MilliSatoshi, receivedWith: IncomingPayment.ReceivedWith, receivedAt: Long = currentTimestampMillis())
 
+    /** Add and receive a payment. Use this method when receiving a spontaneous payment, for example a swap-in payment. */
+    suspend fun addAndReceivePayment(preimage: ByteVector32, origin: IncomingPayment.Origin, amount: MilliSatoshi, receivedWith: IncomingPayment.ReceivedWith, createdAt: Long = currentTimestampMillis(), receivedAt: Long = currentTimestampMillis())
+
     /** List received payments (with most recent payments first). */
     suspend fun listReceivedPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter> = setOf()): List<IncomingPayment>
 }
@@ -115,8 +118,8 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
         /** KeySend payments are spontaneous donations for which we didn't create an invoice. */
         object KeySend : Origin()
 
-        /** Swap-in works by sending an on-chain transaction to a swap server, which will pay us in exchange. */
-        data class SwapIn(val amount: MilliSatoshi, val address: String, val paymentRequest: PaymentRequest?) : Origin()
+        /** Swap-in works by sending an on-chain transaction to a swap server, which will pay us in exchange. We may not know the origin address. */
+        data class SwapIn(val address: String?) : Origin()
 
         fun matchesFilters(filters: Set<PaymentTypeFilter>): Boolean = when (this) {
             is Invoice -> filters.isEmpty() || filters.contains(PaymentTypeFilter.Normal)
@@ -128,15 +131,15 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
     data class Received(val amount: MilliSatoshi, val receivedWith: ReceivedWith, val receivedAt: Long = currentTimestampMillis())
 
     sealed class ReceivedWith {
-        abstract val fees: MilliSatoshi
+        abstract val fees: MilliSatoshi?
 
         /** Payment was received via existing lightning channels. */
         object LightningPayment : ReceivedWith() {
-            override val fees: MilliSatoshi = 0.msat
+            override val fees: MilliSatoshi? = null // with Lightning, the fee is paid by the sender
         }
 
         /** Payment was received via a new channel opened to us. */
-        data class NewChannel(override val fees: MilliSatoshi, val channelId: ByteVector32?) : ReceivedWith()
+        data class NewChannel(override val fees: MilliSatoshi?, val channelId: ByteVector32?) : ReceivedWith()
     }
 
     /** A payment expires if its origin is [Origin.Invoice] and its invoice has expired. [Origin.KeySend] or [Origin.SwapIn] do not expire. */

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -131,7 +131,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
     data class Received(val amount: MilliSatoshi, val receivedWith: ReceivedWith, val receivedAt: Long = currentTimestampMillis())
 
     sealed class ReceivedWith {
-        abstract val fees: MilliSatoshi?
+        abstract val fees: MilliSatoshi
 
         /** Payment was received via existing lightning channels. */
         object LightningPayment : ReceivedWith() {

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -135,11 +135,11 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
 
         /** Payment was received via existing lightning channels. */
         object LightningPayment : ReceivedWith() {
-            override val fees: MilliSatoshi? = null // with Lightning, the fee is paid by the sender
+            override val fees: MilliSatoshi = 0.msat // with Lightning, the fee is paid by the sender
         }
 
         /** Payment was received via a new channel opened to us. */
-        data class NewChannel(override val fees: MilliSatoshi?, val channelId: ByteVector32?) : ReceivedWith()
+        data class NewChannel(override val fees: MilliSatoshi, val channelId: ByteVector32?) : ReceivedWith()
     }
 
     /** A payment expires if its origin is [Origin.Invoice] and its invoice has expired. [Origin.KeySend] or [Origin.SwapIn] do not expire. */

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -372,7 +372,7 @@ class Peer(
                     when (action.origin) {
                         null -> {
                             logger.warning { "n:$remoteNodeId c:$actualChannelId incoming amount with empty origin, store minimal information" }
-                            val fakePreimage = Crypto.sha256(actualChannelId).toByteVector32()
+                            val fakePreimage = actualChannelId.sha256()
                             db.payments.addAndReceivePayment(
                                 preimage = fakePreimage,
                                 origin = IncomingPayment.Origin.SwapIn(address = ""),
@@ -391,7 +391,7 @@ class Peer(
                             }
                         }
                         is ChannelOrigin.SwapInOrigin -> {
-                            val fakePreimage = Crypto.sha256(actualChannelId).toByteVector32()
+                            val fakePreimage = actualChannelId.sha256()
                             db.payments.addAndReceivePayment(
                                 preimage = fakePreimage,
                                 origin = IncomingPayment.Origin.SwapIn(address = action.origin.bitcoinAddress),

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -377,7 +377,7 @@ class Peer(
                                 preimage = fakePreimage,
                                 origin = IncomingPayment.Origin.SwapIn(address = ""),
                                 amount = action.amount,
-                                receivedWith = IncomingPayment.ReceivedWith.NewChannel(fees = null, channelId = actualChannelId)
+                                receivedWith = IncomingPayment.ReceivedWith.NewChannel(fees = 0.msat, channelId = actualChannelId)
                             )
                         }
                         is ChannelOrigin.PayToOpenOrigin -> {

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -367,6 +367,40 @@ class Peer(
                 action is ChannelAction.Storage.StoreHtlcInfos -> {
                     action.htlcs.forEach { db.channels.addHtlcInfo(actualChannelId, it.commitmentNumber, it.paymentHash, it.cltvExpiry) }
                 }
+                action is ChannelAction.Storage.StoreIncomingAmount -> {
+                    logger.info { "storing incoming amount=${action.amount} with origin=${action.origin}" }
+                    when (action.origin) {
+                        null -> {
+                            logger.warning { "n:$remoteNodeId c:$actualChannelId incoming amount with empty origin, store minimal information" }
+                            val fakePreimage = Crypto.sha256(actualChannelId).toByteVector32()
+                            db.payments.addAndReceivePayment(
+                                preimage = fakePreimage,
+                                origin = IncomingPayment.Origin.SwapIn(address = ""),
+                                amount = action.amount,
+                                receivedWith = IncomingPayment.ReceivedWith.NewChannel(fees = null, channelId = actualChannelId)
+                            )
+                        }
+                        is ChannelOrigin.PayToOpenOrigin -> {
+                            if (db.payments.getIncomingPayment(action.origin.paymentHash) != null) {
+                                db.payments.receivePayment(paymentHash = action.origin.paymentHash, amount = action.amount, receivedWith = IncomingPayment.ReceivedWith.NewChannel(
+                                    fees = action.origin.fee.toMilliSatoshi(),
+                                    channelId = actualChannelId
+                                ))
+                            } else {
+                                logger.warning { "n:$remoteNodeId c:$actualChannelId ignored pay-to-open storage, no payments in db for hash=${action.origin.paymentHash}" }
+                            }
+                        }
+                        is ChannelOrigin.SwapInOrigin -> {
+                            val fakePreimage = Crypto.sha256(actualChannelId).toByteVector32()
+                            db.payments.addAndReceivePayment(
+                                preimage = fakePreimage,
+                                origin = IncomingPayment.Origin.SwapIn(address = action.origin.bitcoinAddress),
+                                amount = action.amount,
+                                receivedWith = IncomingPayment.ReceivedWith.NewChannel(fees = action.origin.fee.toMilliSatoshi(), channelId = actualChannelId)
+                            )
+                        }
+                    }
+                }
                 action is ChannelAction.Storage.GetHtlcInfos -> {
                     val htlcInfos = db.channels.listHtlcInfos(actualChannelId, action.commitmentNumber).map { ChannelAction.Storage.HtlcInfo(actualChannelId, action.commitmentNumber, it.first, it.second) }
                     input.send(WrappedChannelEvent(actualChannelId, ChannelEvent.GetHtlcInfosResponse(action.revokedCommitTxId, htlcInfos)))

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -304,7 +304,7 @@ class Peer(
 
     fun openListenerEventSubscription() = listenerEventChannel.openSubscription()
 
-    private suspend fun sendToPeer(msg: LightningMessage) {
+    suspend fun sendToPeer(msg: LightningMessage) {
         val encoded = LightningMessage.encode(msg)
         // Avoids polluting the logs with pongs
         if (msg !is Pong) logger.info { "n:$remoteNodeId sending $msg" }

--- a/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/wire/LightningMessages.kt
@@ -319,7 +319,8 @@ data class OpenChannel(
             @Suppress("UNCHECKED_CAST")
             val readers = mapOf(
                 ChannelTlv.UpfrontShutdownScript.tag to ChannelTlv.UpfrontShutdownScript.Companion as TlvValueReader<ChannelTlv>,
-                ChannelTlv.ChannelVersionTlv.tag to ChannelTlv.ChannelVersionTlv.Companion as TlvValueReader<ChannelTlv>
+                ChannelTlv.ChannelVersionTlv.tag to ChannelTlv.ChannelVersionTlv.Companion as TlvValueReader<ChannelTlv>,
+                ChannelTlv.ChannelOriginTlv.tag to ChannelTlv.ChannelOriginTlv.Companion as TlvValueReader<ChannelTlv>
             )
             return OpenChannel(
                 ByteVector32(LightningCodecs.bytes(input, 32)),


### PR DESCRIPTION
This PR stores new channels as incoming payment in the payments database. It does not implement the actual database query.

As a side effect, the `IncomingPayment.Origin.SwapIn` object has been simplified (only the address field was needed).