### PR TITLE
Phoenix-kmm issue #123: Missing transactions when closing channels

### DIFF
--- a/eclair-kmp-test-fixtures/src/commonMain/kotlin/fr/acinq/eclair/tests/TestConstants.kt
+++ b/eclair-kmp-test-fixtures/src/commonMain/kotlin/fr/acinq/eclair/tests/TestConstants.kt
@@ -1,9 +1,6 @@
 package fr.acinq.eclair.tests
 
-import fr.acinq.bitcoin.Block
-import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.Script
+import fr.acinq.bitcoin.*
 import fr.acinq.eclair.*
 import fr.acinq.eclair.Eclair.randomKey
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
@@ -92,9 +89,10 @@ object TestConstants {
             enableTrampolinePayment = true
         )
 
+        val closingPubKeyInfo = keyManager.closingPubkeyScript(PublicKey.Generator)
         val channelParams: LocalParams = PeerChannels.makeChannelParams(
             nodeParams,
-            ByteVector(Script.write(Script.pay2wpkh(randomKey().publicKey()))),
+            defaultFinalScriptPubkey = ByteVector(closingPubKeyInfo.second),
             isFunder = true,
             fundingAmount
         ).copy(channelReserve = 10_000.sat) // Bob will need to keep that much satoshis as direct payment
@@ -159,9 +157,10 @@ object TestConstants {
             enableTrampolinePayment = true
         )
 
+        val closingPubKeyInfo = keyManager.closingPubkeyScript(PublicKey.Generator)
         val channelParams: LocalParams = PeerChannels.makeChannelParams(
             nodeParams,
-            ByteVector(Script.write(Script.pay2wpkh(randomKey().publicKey()))),
+            defaultFinalScriptPubkey = ByteVector(closingPubKeyInfo.second),
             isFunder = false,
             fundingAmount
         ).copy(channelReserve = 20_000.sat) // Alice will need to keep that much satoshis as direct payment

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2928,7 +2928,7 @@ data class Closing(
             val confirmedTxids = it.irrevocablySpent.values.toSet()
             val allTxs = listOfNotNull(it.commitTx, it.claimMainOutputTx) + it.claimHtlcSuccessTxs + it.claimHtlcTimeoutTxs
             val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
-            if (confirmedTxs.size > 0) {
+            if (confirmedTxs.isNotEmpty()) {
                 txids += confirmedTxs.map { it.txid }
                 claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
                 type = ChannelClosingType.Remote

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2938,7 +2938,7 @@ data class Closing(
             val confirmedTxids = it.irrevocablySpent.values.toSet()
             val allTxs = listOfNotNull(it.commitTx, it.claimMainOutputTx, it.mainPenaltyTx) + it.htlcPenaltyTxs + it.claimHtlcDelayedPenaltyTxs
             val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
-            if (confirmedTxs.size > 0) {
+            if (confirmedTxs.isNotEmpty()) {
                 txids += confirmedTxs.map { it.txid }
                 claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
                 type = ChannelClosingType.Other

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -759,10 +759,10 @@ data class Offline(val state: ChannelStateWithCommitments) : ChannelState() {
                                 currentTip,
                                 currentOnChainFeerates,
                                 state.commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(closingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(closingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -1030,10 +1030,10 @@ data class Syncing(val state: ChannelStateWithCommitments, val waitForTheirReest
                                 currentTip,
                                 currentOnChainFeerates,
                                 state.commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                state.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(closingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = state.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(closingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2367,10 +2367,10 @@ data class Negotiating(
                                 currentTip,
                                 currentOnChainFeerates,
                                 commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                this.closingTxProposed.flatten().map { it.unsignedTx },
-                                listOf(signedClosingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx },
+                                mutualClosePublished = listOf(signedClosingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2388,10 +2388,10 @@ data class Negotiating(
                                 currentTip,
                                 currentOnChainFeerates,
                                 commitments,
-                                null,
-                                currentBlockHeight.toLong(),
-                                this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
-                                listOf(signedClosingTx)
+                                fundingTx = null,
+                                waitingSinceBlock = currentBlockHeight.toLong(),
+                                mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(signedClosingTx),
+                                mutualClosePublished = listOf(signedClosingTx)
                             )
                             val actions = listOf(
                                 ChannelAction.Storage.StoreState(nextState),
@@ -2435,10 +2435,10 @@ data class Negotiating(
                             currentTip,
                             currentOnChainFeerates,
                             commitments,
-                            null,
-                            currentBlockHeight.toLong(),
-                            this.closingTxProposed.flatten().map { it.unsignedTx },
-                            listOf(closingTx)
+                            fundingTx = null,
+                            waitingSinceBlock = currentBlockHeight.toLong(),
+                            mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx },
+                            mutualClosePublished = listOf(closingTx)
                         )
                         val actions = listOf(
                             ChannelAction.Storage.StoreState(nextState),
@@ -2482,10 +2482,10 @@ data class Negotiating(
                     currentTip,
                     currentOnChainFeerates,
                     commitments,
-                    null,
-                    currentBlockHeight.toLong(),
-                    this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
-                    listOf(bestUnpublishedClosingTx)
+                    fundingTx = null,
+                    waitingSinceBlock = currentBlockHeight.toLong(),
+                    mutualCloseProposed = this.closingTxProposed.flatten().map { it.unsignedTx } + listOf(bestUnpublishedClosingTx),
+                    mutualClosePublished = listOf(bestUnpublishedClosingTx)
                 )
                 val actions = listOf(
                     ChannelAction.Storage.StoreState(nextState),

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2899,7 +2899,8 @@ data class Closing(
             remoteCommitPublished != null -> ChannelClosingType.Remote
             nextRemoteCommitPublished != null -> ChannelClosingType.Remote
             futureRemoteCommitPublished != null -> ChannelClosingType.Remote
-            else -> ChannelClosingType.Other // includes revoked commit published case
+            revokedCommitPublished.isNotEmpty() -> ChannelClosingType.Revoked
+            else -> ChannelClosingType.Other
         }
         additionalConfirmedTx?.let { confirmedTx ->
             mutualClosePublished.firstOrNull { it.tx == confirmedTx }?.let {

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2914,7 +2914,7 @@ data class Closing(
             val confirmedTxids = it.irrevocablySpent.values.toSet()
             val allTxs = listOfNotNull(it.commitTx, it.claimMainDelayedOutputTx) + it.htlcSuccessTxs + it.htlcTimeoutTxs
             val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
-            if (confirmedTxs.size > 0) {
+            if (confirmedTxs.isNotEmpty()) {
                 txids += confirmedTxs.map { it.txid }
                 claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
                 type = ChannelClosingType.Local

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -96,7 +96,7 @@ sealed class ChannelAction {
         data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()
         data class StoreIncomingAmount(val amount: MilliSatoshi, val origin: ChannelOrigin?) : Storage()
         data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isLocalWallet: Boolean) : Storage()
-        data class CompleteChannelClosing(val txids: List<ByteVector32>, val claimed: Satoshi) : Storage()
+        data class StoreChannelClosed(val txids: List<ByteVector32>, val claimed: Satoshi) : Storage()
     }
 
     data class ProcessIncomingHtlc(val add: UpdateAddHtlc) : ChannelAction()
@@ -2678,7 +2678,7 @@ data class Closing(
                                 if (closingType !is MutualClose) {
                                     logger.debug { "c:$channelId last known remoteChannelData=${commitments.remoteChannelData}" }
                                 }
-                                Pair(Closed(closing1), listOf(closing1.completeChannelClosing(watch.tx)))
+                                Pair(Closed(closing1), listOf(closing1.storeChannelClosed(watch.tx)))
                             }
                         }
                         val actions = buildList {
@@ -2888,7 +2888,7 @@ data class Closing(
         }
     }
 
-    private fun completeChannelClosing(additionalConfirmedTx: Transaction?): ChannelAction.Storage.CompleteChannelClosing {
+    private fun storeChannelClosed(additionalConfirmedTx: Transaction?): ChannelAction.Storage.StoreChannelClosed {
         // We want to give the user the list of btc transactions for their outputs
         val txids = mutableListOf<ByteVector32>()
         var claimed = 0.sat
@@ -2932,7 +2932,7 @@ data class Closing(
             txids += confirmedTxs.map { it.txid }
             claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
         }
-        return ChannelAction.Storage.CompleteChannelClosing(txids, claimed)
+        return ChannelAction.Storage.StoreChannelClosed(txids, claimed)
     }
 }
 

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2673,7 +2673,7 @@ data class Closing(
                         }
 
                         val (nextState, closedActions) = when (val closingType = closing1.isClosed(watch.tx)) {
-                            null -> Pair(closing1, listOf<ChannelAction>())
+                            null -> Pair(closing1, listOf())
                             else -> {
                                 logger.info { "c:$channelId channel is now closed" }
                                 if (closingType !is MutualClose) {

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2626,7 +2626,11 @@ data class Closing(
                             futureRemoteCommitPublished = this.futureRemoteCommitPublished?.update(watch.tx),
                             revokedCommitPublished = this.revokedCommitPublished.map { it.update(watch.tx) }
                         )
-                        closing1.networkFeePaid(watch.tx)?.let { logger.info { "c:$channelId paid fee=${it.first} for txid=${watch.tx.txid} desc=${it.second}" } }
+                        closing1.networkFeePaid(watch.tx)?.let {
+                            logger.info { "c:$channelId paid fee=${it.first} for txid=${watch.tx.txid} desc=${it.second}" }
+                        } ?: run {
+                            logger.info { "c:$channelId paid UNKNOWN fee for txid=${watch.tx.txid}" }
+                        }
 
                         // we may need to fail some htlcs in case a commitment tx was published and they have reached the timeout threshold
                         val htlcSettledActions = mutableListOf<ChannelAction>()

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -96,7 +96,7 @@ sealed class ChannelAction {
         data class StoreHtlcInfos(val htlcs: List<HtlcInfo>) : Storage()
         data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()
         data class StoreIncomingAmount(val amount: MilliSatoshi, val origin: ChannelOrigin?) : Storage()
-        data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isSentToMyWallet: Boolean) : Storage()
+        data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isSentToDefaultAddress: Boolean) : Storage()
         data class StoreChannelClosed(val txids: List<ByteVector32>, val claimed: Satoshi, val type: ChannelClosingType) : Storage()
     }
 
@@ -185,7 +185,7 @@ sealed class ChannelState {
                             actions + ChannelAction.Storage.StoreChannelClosing(
                                 amount = channelBalance,
                                 closingAddress = btcAddr,
-                                isSentToMyWallet = false
+                                isSentToDefaultAddress = false
                             )
                         } else {
                             // Default output address
@@ -196,7 +196,7 @@ sealed class ChannelState {
                             actions + ChannelAction.Storage.StoreChannelClosing(
                                 amount = channelBalance,
                                 closingAddress = btcAddr,
-                                isSentToMyWallet = true
+                                isSentToDefaultAddress = true
                             )
                         }
                     } else /* channelBalance <= 0.msat */ {

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -96,7 +96,7 @@ sealed class ChannelAction {
         data class StoreHtlcInfos(val htlcs: List<HtlcInfo>) : Storage()
         data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()
         data class StoreIncomingAmount(val amount: MilliSatoshi, val origin: ChannelOrigin?) : Storage()
-        data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isLocalWallet: Boolean) : Storage()
+        data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isSentToMyWallet: Boolean) : Storage()
         data class StoreChannelClosed(val txids: List<ByteVector32>, val claimed: Satoshi, val type: ChannelClosingType) : Storage()
     }
 
@@ -185,7 +185,7 @@ sealed class ChannelState {
                             actions + ChannelAction.Storage.StoreChannelClosing(
                                 amount = channelBalance,
                                 closingAddress = btcAddr,
-                                isLocalWallet = false
+                                isSentToMyWallet = false
                             )
                         } else {
                             // Default output address
@@ -196,7 +196,7 @@ sealed class ChannelState {
                             actions + ChannelAction.Storage.StoreChannelClosing(
                                 amount = channelBalance,
                                 closingAddress = btcAddr,
-                                isLocalWallet = true
+                                isSentToMyWallet = true
                             )
                         }
                     } else /* channelBalance <= 0.msat */ {

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -2914,7 +2914,7 @@ data class Closing(
             val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
             if (confirmedTxs.isNotEmpty()) {
                 txids += confirmedTxs.map { it.txid }
-                claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
+                claimed += confirmedTxs.map { it.txOut.first().amount }.sum()
             }
         }
         listOfNotNull(
@@ -2928,7 +2928,7 @@ data class Closing(
             val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
             if (confirmedTxs.isNotEmpty()) {
                 txids += confirmedTxs.map { it.txid }
-                claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
+                claimed += confirmedTxs.map { it.txOut.first().amount }.sum()
             }
         }
         revokedCommitPublished.forEach {
@@ -2939,7 +2939,7 @@ data class Closing(
             val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
             if (confirmedTxs.isNotEmpty()) {
                 txids += confirmedTxs.map { it.txid }
-                claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
+                claimed += confirmedTxs.map { it.txOut.first().amount }.sum()
             }
         }
         return ChannelAction.Storage.StoreChannelClosed(txids, claimed, type)

--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Helpers.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Helpers.kt
@@ -363,6 +363,46 @@ object Helpers {
 
         fun isValidFinalScriptPubkey(scriptPubKey: ByteVector): Boolean = isValidFinalScriptPubkey(scriptPubKey.toByteArray())
 
+        fun btcAddressFromScriptPubKey(scriptPubKey: ByteVector, chainHash: ByteVector32): String? {
+            return runTrying {
+                val script = Script.parse(scriptPubKey)
+                when {
+                    Script.isPay2pkh(script) -> {
+                        // OP_DUP OP_HASH160 OP_PUSHDATA(20) OP_EQUALVERIFY OP_CHECKSIG
+                        val opPushData = script[2] as OP_PUSHDATA
+                        val prefix = when (chainHash) {
+                            Block.LivenetGenesisBlock.hash -> Base58.Prefix.PubkeyAddress
+                            Block.TestnetGenesisBlock.hash -> Base58.Prefix.PubkeyAddressTestnet
+                            else -> Base58.Prefix.PubkeyAddressSegnet
+                        }
+                        Base58Check.encode(prefix, opPushData.data)
+                    }
+                    Script.isPay2sh(script) -> {
+                        // OP_HASH160 OP_PUSHDATA(20) OP_EQUAL
+                        val opPushData = script[1] as OP_PUSHDATA
+                        val prefix = when (chainHash) {
+                            Block.LivenetGenesisBlock.hash -> Base58.Prefix.ScriptAddress
+                            Block.TestnetGenesisBlock.hash -> Base58.Prefix.ScriptAddressTestnet
+                            else -> Base58.Prefix.ScriptAddressSegnet
+                        }
+                        Base58Check.encode(prefix, opPushData.data)
+                    }
+                    Script.isPay2wpkh(script) || Script.isPay2wsh(script) -> {
+                        // isPay2wpkh : OP_0 OP_PUSHDATA(20)
+                        // isPay2wsh  : OP_0 OP_PUSHDATA(32)
+                        val opPushData = script[1] as OP_PUSHDATA
+                        val hrp = when (chainHash) {
+                            Block.LivenetGenesisBlock.hash -> "bc"
+                            Block.TestnetGenesisBlock.hash -> "tb"
+                            else -> "bcrt"
+                        }
+                        Bech32.encodeWitnessAddress(hrp, 0, opPushData.data.toByteArray())
+                    }
+                    else -> null
+                } // </when>
+            }.getOrElse { null }
+        }
+
         fun firstClosingFee(commitments: Commitments, localScriptPubkey: ByteArray, remoteScriptPubkey: ByteArray, requestedFeerate: FeeratePerKw): Satoshi {
             // this is just to estimate the weight which depends on the size of the pubkey scripts
             val dummyClosingTx = Transactions.makeClosingTx(commitments.commitInput, localScriptPubkey, remoteScriptPubkey, commitments.localParams.isFunder, Satoshi(0), Satoshi(0), commitments.localCommit.spec)

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/InMemoryPaymentsDb.kt
@@ -56,14 +56,7 @@ class InMemoryPaymentsDb : PaymentsDb {
         return outgoing[id]?.let { payment ->
             val parts = outgoingParts.values.filter { it.first == payment.id }.map { it.second }
             return when (payment.status) {
-                // This doesn't work. Is there something like "instanceof" to check inheritance ???
-            //  is OutgoingPayment.Status.Completed.Succeeded -> {
-            //      payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
-            //  }
-                is OutgoingPayment.Status.Completed.Succeeded.OffChain -> {
-                    payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
-                }
-                is OutgoingPayment.Status.Completed.Succeeded.OnChain -> {
+                is OutgoingPayment.Status.Completed.Succeeded -> {
                     payment.copy(parts = parts.filter { it.status is OutgoingPayment.Part.Status.Succeeded })
                 }
                 else -> payment.copy(parts = parts)

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -205,7 +205,7 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
         data class ChannelClosing(
             val channelId: ByteVector32,
             val closingAddress: String,
-            val isSentToMyWallet: Boolean,
+            val isSentToDefaultAddress: Boolean,
             override val paymentHash: ByteVector32
         ) : Details()
 

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -47,19 +47,11 @@ interface OutgoingPaymentsDb {
     /** Mark an outgoing payment as completed (failed, succeeded, mined). */
     suspend fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed)
 
-    suspend fun completeOutgoingPayment(id: UUID, finalFailure: FinalFailure, completedAt: Long? = null) =
-        if (completedAt != null) {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure, completedAt))
-        } else {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure))
-        }
+    suspend fun completeOutgoingPayment(id: UUID, finalFailure: FinalFailure, completedAt: Long = currentTimestampMillis()) =
+        completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure, completedAt))
 
-    suspend fun completeOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long? = null) =
-        if (completedAt != null) {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, completedAt))
-        } else {
-            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage))
-        }
+    suspend fun completeOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis()) =
+        completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, completedAt))
 
     /** Add new partial payments to a pending outgoing payment. */
     suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>)

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -196,9 +196,10 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
             // But in all other cases, the funds are sent to the default Phoenix address derived from the wallet seed.
             // So `isSentToDefaultAddress` means this default Phoenix address was used,
             // and is used by the UI to explain the situation to the user.
-            val isSentToDefaultAddress: Boolean,
-            override val paymentHash: ByteVector32
-        ) : Details()
+            val isSentToDefaultAddress: Boolean
+        ) : Details() {
+            override val paymentHash: ByteVector32 = channelId.sha256()
+        }
 
         fun matchesFilters(filters: Set<PaymentTypeFilter>): Boolean = when (this) {
             is Normal -> filters.isEmpty() || filters.contains(PaymentTypeFilter.Normal)

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -205,7 +205,7 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
         data class ChannelClosing(
             val channelId: ByteVector32,
             val closingAddress: String,
-            val isLocalWallet: Boolean,
+            val isSentToMyWallet: Boolean,
             override val paymentHash: ByteVector32
         ) : Details()
 

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -168,7 +168,7 @@ data class IncomingPayment(val preimage: ByteVector32, val origin: Origin, val r
  * @param parts partial child payments that have actually been sent.
  * @param status current status of the payment.
  */
-data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val recipient: PublicKey, val details: Details, val parts: List<Part>, val status: Status) : WalletPayment() {
+data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val recipient: PublicKey, val details: Details, val parts: List<Part>, val status: Status, val createdAt: Long = currentTimestampMillis()) : WalletPayment() {
     constructor(id: UUID, amount: MilliSatoshi, recipient: PublicKey, details: Details) : this(id, amount, recipient, details, listOf(), Status.Pending)
 
     val paymentHash: ByteVector32 = details.paymentHash

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -3,6 +3,7 @@ package fr.acinq.eclair.db
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.channel.ChannelException
@@ -43,11 +44,22 @@ interface OutgoingPaymentsDb {
     /** Get information about an outgoing payment (settled or not). */
     suspend fun getOutgoingPayment(id: UUID): OutgoingPayment?
 
-    /** Mark an outgoing payment as failed. */
-    suspend fun updateOutgoingPayment(id: UUID, failure: FinalFailure, completedAt: Long = currentTimestampMillis())
+    /** Mark an outgoing payment as completed (failed, succeeded, mined). */
+    suspend fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed)
 
-    /** Mark an outgoing payment as succeeded. This should delete all intermediate failed payment parts and only keep the successful ones. */
-    suspend fun updateOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long = currentTimestampMillis())
+    suspend fun completeOutgoingPayment(id: UUID, finalFailure: FinalFailure, completedAt: Long? = null) =
+        if (completedAt != null) {
+            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure, completedAt))
+        } else {
+            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Failed(finalFailure))
+        }
+
+    suspend fun completeOutgoingPayment(id: UUID, preimage: ByteVector32, completedAt: Long? = null) =
+        if (completedAt != null) {
+            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, completedAt))
+        } else {
+            completeOutgoingPayment(id, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage))
+        }
 
     /** Add new partial payments to a pending outgoing payment. */
     suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>)
@@ -68,7 +80,7 @@ interface OutgoingPaymentsDb {
     suspend fun listOutgoingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter> = setOf()): List<OutgoingPayment>
 }
 
-enum class PaymentTypeFilter { Normal, KeySend, SwapIn, SwapOut }
+enum class PaymentTypeFilter { Normal, KeySend, SwapIn, SwapOut, ChannelClosing }
 
 /** A payment made to or from the wallet. */
 sealed class WalletPayment {
@@ -77,8 +89,7 @@ sealed class WalletPayment {
         fun completedAt(payment: WalletPayment): Long = when (payment) {
             is IncomingPayment -> payment.received?.receivedAt ?: 0
             is OutgoingPayment -> when (val status = payment.status) {
-                is OutgoingPayment.Status.Succeeded -> status.completedAt
-                is OutgoingPayment.Status.Failed -> status.completedAt
+                is OutgoingPayment.Status.Completed -> status.completedAt
                 else -> 0
             }
         }
@@ -162,7 +173,7 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
 
     val paymentHash: ByteVector32 = details.paymentHash
     val fees: MilliSatoshi = when (status) {
-        is Status.Failed -> 0.msat
+        is Status.Completed.Failed -> 0.msat
         else -> parts.filter { it.status is Part.Status.Succeeded || it.status == Part.Status.Pending }.map { it.amount }.sum() - recipientAmount
     }
 
@@ -182,17 +193,26 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
         /** Swaps out send a lightning payment to a swap server, which will send an on-chain transaction to a given address. */
         data class SwapOut(val address: String, override val paymentHash: ByteVector32) : Details()
 
+        data class ChannelClosing(val closingAddress: String, val isLocalWallet: Boolean, override val paymentHash: ByteVector32) : Details()
+
         fun matchesFilters(filters: Set<PaymentTypeFilter>): Boolean = when (this) {
             is Normal -> filters.isEmpty() || filters.contains(PaymentTypeFilter.Normal)
             is KeySend -> filters.isEmpty() || filters.contains(PaymentTypeFilter.KeySend)
             is SwapOut -> filters.isEmpty() || filters.contains(PaymentTypeFilter.SwapOut)
+            is ChannelClosing -> filters.isEmpty() || filters.contains(PaymentTypeFilter.ChannelClosing)
         }
     }
 
     sealed class Status {
         object Pending : Status()
-        data class Succeeded(val preimage: ByteVector32, val completedAt: Long = currentTimestampMillis()) : Status()
-        data class Failed(val reason: FinalFailure, val completedAt: Long = currentTimestampMillis()) : Status()
+        sealed class Completed : Status() {
+            abstract val completedAt: Long
+            data class Failed(val reason: FinalFailure, override val completedAt: Long = currentTimestampMillis()) : Completed()
+            sealed class Succeeded : Completed() {
+                data class OffChain(val preimage: ByteVector32, override val completedAt: Long = currentTimestampMillis()) : Completed()
+                data class OnChain(val txids: List<ByteVector32>, val claimed: Satoshi, override val completedAt: Long = currentTimestampMillis()) : Completed()
+            }
+        }
     }
 
     /**

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -220,6 +220,10 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
                 ) : Succeeded()
                 data class OnChain(
                     val txids: List<ByteVector32>,
+                    // The `claimed` field represents the sum total of bitcoin tx outputs claimed for the user.
+                    // A simplified fees can be calculated as: OutgoingPayment.recipientAmount - claimed
+                    // In the future, we plan on storing the closing btc transactions as parts.
+                    // Then we can use those parts to calculate the fees, and provide more details to the user.
                     val claimed: Satoshi,
                     val type: ChannelClosingType,
                     override val completedAt: Long = currentTimestampMillis()

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -225,7 +225,7 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
                     override val completedAt: Long = currentTimestampMillis()
                 ) : Succeeded() {
                     enum class ChannelClosingType {
-                        Mutual, Local, Remote, Other
+                        Mutual, Local, Remote, Revoked, Other
                     }
                 }
             }

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -191,7 +191,11 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
         /** Corresponds to the on-chain payments made when closing a channel. */
         data class ChannelClosing(
             val channelId: ByteVector32,
-            val closingAddress: String,
+            val closingAddress: String, // btc address
+            // The closingAddress may have been supplied by the user during a mutual close.
+            // But in all other cases, the funds are sent to the default Phoenix address derived from the wallet seed.
+            // So `isSentToDefaultAddress` means this default Phoenix address was used,
+            // and is used by the UI to explain the situation to the user.
             val isSentToDefaultAddress: Boolean,
             override val paymentHash: ByteVector32
         ) : Details()

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -172,10 +172,26 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
     constructor(id: UUID, amount: MilliSatoshi, recipient: PublicKey, details: Details) : this(id, amount, recipient, details, listOf(), Status.Pending)
 
     val paymentHash: ByteVector32 = details.paymentHash
-    val fees: MilliSatoshi = when (status) {
-        is Status.Completed.Failed -> 0.msat
-        else -> parts.filter { it.status is Part.Status.Succeeded || it.status == Part.Status.Pending }.map { it.amount }.sum() - recipientAmount
-    }
+    val fees: MilliSatoshi =
+        if (details is Details.Normal) {
+            when (status) {
+                is Status.Completed.Failed -> 0.msat
+                else -> {
+                    val sum = parts.filter {
+                        it.status is Part.Status.Succeeded || it.status == Part.Status.Pending
+                    }.map { it.amount }.sum()
+                    if (sum < recipientAmount && status is Status.Pending) {
+                        // We don't have all the parts yet, so the total fees are unknown.
+                        0.msat
+                    } else {
+                        sum - recipientAmount
+                    }
+                }
+            }
+
+        } else {
+            0.msat
+        }
 
     sealed class Details {
         abstract val paymentHash: ByteVector32

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -226,13 +226,13 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
                 data class OffChain(
                     val preimage: ByteVector32,
                     override val completedAt: Long = currentTimestampMillis()
-                ) : Completed()
+                ) : Succeeded()
                 data class OnChain(
                     val txids: List<ByteVector32>,
                     val claimed: Satoshi,
                     val type: ChannelClosingType,
                     override val completedAt: Long = currentTimestampMillis()
-                ) : Completed() {
+                ) : Succeeded() {
                     enum class ChannelClosingType {
                         Mutual, Local, Remote, Other
                     }

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -416,7 +416,7 @@ class Peer(
                         details = OutgoingPayment.Details.ChannelClosing(
                             channelId = channelId,
                             closingAddress = action.closingAddress,
-                            isLocalWallet = action.isLocalWallet,
+                            isSentToMyWallet = action.isSentToMyWallet,
                             paymentHash = randomBytes32()
                         ),
                         parts = listOf<OutgoingPayment.Part>(),

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -409,15 +409,15 @@ class Peer(
                 }
                 action is ChannelAction.Storage.StoreChannelClosing -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
+                    val recipient = if (action.isSentToDefaultAddress) nodeParams.nodeId else PublicKey.Generator
                     val payment = OutgoingPayment(
                         id = dbId,
                         recipientAmount = action.amount,
-                        recipient = PublicKey.Generator,
+                        recipient = recipient,
                         details = OutgoingPayment.Details.ChannelClosing(
                             channelId = channelId,
                             closingAddress = action.closingAddress,
-                            isSentToDefaultAddress = action.isSentToDefaultAddress,
-                            paymentHash = randomBytes32()
+                            isSentToDefaultAddress = action.isSentToDefaultAddress
                         ),
                         parts = listOf<OutgoingPayment.Part>(),
                         status = OutgoingPayment.Status.Pending

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -416,7 +416,7 @@ class Peer(
                         details = OutgoingPayment.Details.ChannelClosing(
                             channelId = channelId,
                             closingAddress = action.closingAddress,
-                            isSentToMyWallet = action.isSentToMyWallet,
+                            isSentToDefaultAddress = action.isSentToDefaultAddress,
                             paymentHash = randomBytes32()
                         ),
                         parts = listOf<OutgoingPayment.Part>(),

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -414,6 +414,7 @@ class Peer(
                         recipientAmount = action.amount,
                         recipient = PublicKey.Generator,
                         details = OutgoingPayment.Details.ChannelClosing(
+                            channelId = channelId,
                             closingAddress = action.closingAddress,
                             isLocalWallet = action.isLocalWallet,
                             paymentHash = randomBytes32()
@@ -426,7 +427,7 @@ class Peer(
                 }
                 action is ChannelAction.Storage.StoreChannelClosed -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
-                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed)
+                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed, action.type)
                     db.payments.completeOutgoingPayment(dbId, completed)
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -424,7 +424,7 @@ class Peer(
                     db.payments.addOutgoingPayment(payment)
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }
-                action is ChannelAction.Storage.CompleteChannelClosing -> {
+                action is ChannelAction.Storage.StoreChannelClosed -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
                     val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed)
                     db.payments.completeOutgoingPayment(dbId, completed)

--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandler.kt
@@ -59,10 +59,10 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
         return when (val result = RouteCalculation.findRoutes(request.paymentId, trampolineAmount, channels)) {
             is Either.Left -> {
                 logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${result.value}" }
-                val failure = result.value.toPaymentFailure()
                 db.addOutgoingPayment(OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details))
-                db.updateOutgoingPayment(request.paymentId, failure.reason)
-                Failure(request, failure)
+                val finalFailure = result.value
+                db.completeOutgoingPayment(request.paymentId, finalFailure)
+                Failure(request, finalFailure.toPaymentFailure())
             }
             is Either.Right -> {
                 // We generate a random secret for this payment to avoid leaking the invoice secret to the trampoline node.
@@ -159,7 +159,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                                 logger.warning { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment failed: ${routes.value}" }
                                 val aborted = PaymentAttempt.PaymentAborted(payment.request, routes.value, mapOf(), payment.failures + Either.Right(failure))
                                 val result = Failure(payment.request, OutgoingPaymentFailure(aborted.reason, aborted.failures))
-                                db.updateOutgoingPayment(payment.request.paymentId, result.failure.reason)
+                                db.completeOutgoingPayment(payment.request.paymentId, result.failure.reason)
                                 Pair(aborted, result)
                             }
                             is Either.Right -> {
@@ -204,7 +204,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val hasMorePendingParts = payment.parts.any { it.status == OutgoingPayment.Part.Status.Pending && it.id != partId }
                 return if (!hasMorePendingParts) {
                     logger.warning { "h:${payment.paymentHash} p:${payment.id} payment failed: ${FinalFailure.WalletRestarted}" }
-                    db.updateOutgoingPayment(payment.id, FinalFailure.WalletRestarted)
+                    db.completeOutgoingPayment(payment.id, FinalFailure.WalletRestarted)
                     Failure(
                         SendPayment(payment.id, payment.recipientAmount, payment.recipient, payment.details as OutgoingPayment.Details.Normal),
                         OutgoingPaymentFailure(FinalFailure.WalletRestarted, payment.parts.map { it.status }.filterIsInstance<OutgoingPayment.Part.Status.Failed>() + OutgoingPaymentFailure.convertFailure(failure))
@@ -239,9 +239,9 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
 
         return if (updated.isComplete()) {
             logger.info { "h:${payment.request.paymentHash} p:${payment.request.paymentId} payment successfully sent (fees=${updated.fees})" }
-            db.updateOutgoingPayment(payment.request.paymentId, preimage)
+            db.completeOutgoingPayment(payment.request.paymentId, preimage)
             val r = payment.request
-            Success(r, OutgoingPayment(r.paymentId, r.amount, r.recipient, r.details, updated.parts, OutgoingPayment.Status.Succeeded(preimage)), preimage)
+            Success(r, OutgoingPayment(r.paymentId, r.amount, r.recipient, r.details, updated.parts, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage)), preimage)
         } else {
             PreimageReceived(payment.request, preimage)
         }
@@ -261,7 +261,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val hasMorePendingParts = payment.parts.any { it.status == OutgoingPayment.Part.Status.Pending && it.id != partId }
                 return if (!hasMorePendingParts) {
                     logger.info { "h:${payment.paymentHash} p:${payment.id} payment successfully sent (wallet restart)" }
-                    db.updateOutgoingPayment(payment.id, preimage)
+                    db.completeOutgoingPayment(payment.id, preimage)
                     val succeeded = db.getOutgoingPayment(payment.id)!! //  NB: we reload the payment to ensure all parts status are updated
                     Success(request, succeeded, preimage)
                 } else {
@@ -378,7 +378,7 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val updated = copy(pending = pending - childId, failures = failures + failure)
                 val result = if (updated.isComplete()) {
                     logger.warning { "h:${request.paymentHash} p:${request.paymentId} payment failed: ${updated.reason}" }
-                    db.updateOutgoingPayment(request.paymentId, updated.reason)
+                    db.completeOutgoingPayment(request.paymentId, updated.reason)
                     Failure(request, OutgoingPaymentFailure(updated.reason, updated.failures))
                 } else {
                     null
@@ -412,8 +412,8 @@ class OutgoingPaymentHandler(val nodeId: PublicKey, val walletParams: WalletPara
                 val updated = copy(pending = pending - childId)
                 val result = if (updated.isComplete()) {
                     logger.info { "h:${request.paymentHash} p:${request.paymentId} payment successfully sent (fees=${updated.fees})" }
-                    db.updateOutgoingPayment(request.paymentId, preimage)
-                    Success(request, OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details, parts, OutgoingPayment.Status.Succeeded(preimage)), preimage)
+                    db.completeOutgoingPayment(request.paymentId, preimage)
+                    Success(request, OutgoingPayment(request.paymentId, request.amount, request.recipient, request.details, parts, OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage)), preimage)
                 } else {
                     null
                 }

--- a/src/commonMain/kotlin/fr/acinq/eclair/utils/UUID.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/utils/UUID.kt
@@ -90,6 +90,11 @@ class UUID(val mostSignificantBits: Long, val leastSignificantBits: Long) : Comp
 
         fun randomUUID(): UUID {
             val data = ByteArray(16).also { Random.secure().nextBytes(it) }
+            return fromBytes(data)
+        }
+
+        fun fromBytes(data: ByteArray): UUID {
+            require(data.size == 16) { "data must be exactly 16 bytes" }
             data[6] = (data[6].toInt() and 0x0F).toByte()
             data[6] = (data[6].toInt() or 0x40).toByte()
             data[8] = (data[8].toInt() and 0x3F).toByte()

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/HelpersTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/HelpersTestsCommon.kt
@@ -1,0 +1,48 @@
+package fr.acinq.eclair.channel
+
+import fr.acinq.bitcoin.*
+import fr.acinq.eclair.tests.utils.EclairTestSuite
+import fr.acinq.secp256k1.Hex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HelpersTestsCommon : EclairTestSuite() {
+
+    @Test
+    fun `compute address from pubkey script`() {
+        val pub = PrivateKey(Hex.decode("0101010101010101010101010101010101010101010101010101010101010101")).publicKey()
+
+        fun address(script: List<ScriptElt>, chainHash: ByteVector32) =
+            Helpers.Closing.btcAddressFromScriptPubKey(ByteVector(Script.write(script)), chainHash)
+
+
+        listOf(Block.LivenetGenesisBlock.hash, Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash).forEach {
+            assertEquals(address(Script.pay2pkh(pub), it), computeP2PkhAddress(pub, it))
+            assertEquals(address(Script.pay2wpkh(pub), it), computeP2WpkhAddress(pub, it))
+            assertEquals(address(Script.pay2sh(Script.pay2wpkh(pub)), it), computeP2ShOfP2WpkhAddress(pub, it))
+            // all these chain hashes are invalid
+            assertEquals(address(Script.pay2pkh(pub), it.reversed()), null)
+            assertEquals(address(Script.pay2wpkh(pub), it.reversed()), null)
+            assertEquals(address(Script.pay2sh(Script.pay2wpkh(pub)), it.reversed()), null)
+        }
+
+        listOf(
+                Triple("0014d0b19277b0f76c9512f26d77573fd31a8fd15fc7", Block.TestnetGenesisBlock.hash, "tb1q6zceyaas7akf2yhjd4m4w07nr28azh78gw79kk"),
+                Triple("00203287047df2aa7aade3f394790a9c9d6f9235943f48a012e8a9f2c3300ca4f2d1", Block.TestnetGenesisBlock.hash, "tb1qx2rsgl0j4fa2mclnj3us48yad7frt9plfzsp969f7tpnqr9y7tgsyprxej"),
+                Triple("76a914b17deefe2feab87fef7221cf806bb8ca61f00fa188ac", Block.TestnetGenesisBlock.hash, "mwhSm2SHhRhd19KZyaQLgJyAtCLnkbzWbf"),
+                Triple("a914d3cf9d04f4ecc36df8207b300e46bc6775fc84c087", Block.TestnetGenesisBlock.hash, "2NCZBGzKadAnLv1ijAqhrKavMuqvxqu18yY"),
+                Triple("00145cb882efd643b7d63ae133e4d5e88e10bd5a20d7", Block.LivenetGenesisBlock.hash, "bc1qtjug9m7kgwmavwhpx0jdt6ywzz745gxhxwyn8u"),
+                Triple("00208c2865c87ffd33fc5d698c7df9cf2d0fb39d93103c637a06dea32c848ebc3e1d", Block.LivenetGenesisBlock.hash, "bc1q3s5xtjrll5elchtf337lnnedp7eemycs833h5pk75vkgfr4u8cws3ytg02"),
+                Triple("76a914536ffa992491508dca0354e52f32a3a7a679a53a88ac", Block.LivenetGenesisBlock.hash, "18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX"),
+                Triple("a91481b9ac6a59b53927da7277b5ad5460d781b365d987", Block.LivenetGenesisBlock.hash, "3DWwX7NYjnav66qygrm4mBCpiByjammaWy"),
+        ).forEach {
+            assertEquals(
+                Helpers.Closing.btcAddressFromScriptPubKey(
+                    scriptPubKey = ByteVector(Hex.decode(it.first)),
+                    chainHash = it.second
+                ),
+                it.third
+            )
+        }
+    }
+}

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/TestsHelper.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/TestsHelper.kt
@@ -168,12 +168,17 @@ object TestsHelper {
         return Pair(alice as Normal, bob as Normal)
     }
 
-    fun mutualClose(alice: Normal, bob: Normal, tweakFees: Boolean = false): Triple<Negotiating, Negotiating, ClosingSigned> {
+    fun mutualClose(
+        alice: Normal,
+        bob: Normal,
+        tweakFees: Boolean = false,
+        scriptPubKey: ByteVector? = null
+    ): Triple<Negotiating, Negotiating, ClosingSigned> {
         val alice1 = alice.updateFeerate(if (tweakFees) FeeratePerKw(4_319.sat) else FeeratePerKw(10_000.sat))
         val bob1 = bob.updateFeerate(if (tweakFees) FeeratePerKw(4_319.sat) else FeeratePerKw(10_000.sat))
 
         // Bob is fundee and initiates the closing
-        val (bob2, actions) = bob1.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(null)))
+        val (bob2, actions) = bob1.process(ChannelEvent.ExecuteCommand(CMD_CLOSE(scriptPubKey)))
         assertTrue(bob2 is Normal)
         val shutdown = actions.findOutgoingMessage<Shutdown>()
 

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -514,7 +514,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         val (aliceClosed, actions) = alice.processEx(ChannelEvent.WatchReceived(watchConfirmed.last()))
         assertTrue(aliceClosed is Closed)
         assertTrue(actions.contains(ChannelAction.Storage.StoreState(aliceClosed)))
-        assertNotNull(actions.filterIsInstance<ChannelAction.Storage.CompleteChannelClosing>().firstOrNull())
+        assertNotNull(actions.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull())
         // We notify the payment handler that the non-dust htlc has been failed.
         val htlcFail = actions.filterIsInstance<ChannelAction.ProcessCmdRes.AddSettledFail>().first()
         assertEquals(htlcs[0], htlcFail.htlc)
@@ -1077,7 +1077,7 @@ class ClosingTestsCommon : EclairTestSuite() {
             listOf(ChannelAction.Storage.StoreState(alice5)),
             aliceActions5.filterIsInstance<ChannelAction.Storage.StoreState>()
         )
-        assertEquals(1, aliceActions5.filterIsInstance<ChannelAction.Storage.CompleteChannelClosing>().size)
+        assertEquals(1, aliceActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().size)
     }
 
     @Test
@@ -1726,7 +1726,7 @@ class ClosingTestsCommon : EclairTestSuite() {
                 when (action) {
                     is ChannelAction.ProcessCmdRes -> true
                     is ChannelAction.Storage.StoreChannelClosing -> true
-                    is ChannelAction.Storage.CompleteChannelClosing -> true
+                    is ChannelAction.Storage.StoreChannelClosed -> true
                     else -> false
                 }
             })

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -1742,9 +1742,9 @@ class ClosingTestsCommon : EclairTestSuite() {
 
                 val channelBalance = alice1.commitments.localCommit.spec.toLocal
                 if (channelBalance > 0.msat) {
-                    val ledgerPayment = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
-                    assertNotNull(ledgerPayment)
-                    assertTrue(ledgerPayment.amount == channelBalance)
+                    val onChainPayment = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
+                    assertNotNull(onChainPayment)
+                    assertTrue(onChainPayment.amount == channelBalance)
                 }
 
                 val error = actions1.hasOutgoingMessage<Error>()
@@ -1775,9 +1775,9 @@ class ClosingTestsCommon : EclairTestSuite() {
 
                 val channelBalance = bob1.commitments.localCommit.spec.toLocal
                 if (channelBalance > 0.msat) {
-                    val ledgerPayment = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
-                    assertNotNull(ledgerPayment)
-                    assertTrue(ledgerPayment.amount == channelBalance)
+                    val onChainPayment = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosing>().firstOrNull()
+                    assertNotNull(onChainPayment)
+                    assertTrue(onChainPayment.amount == channelBalance)
                 }
 
                 val error = actions1.hasOutgoingMessage<Error>()

--- a/src/commonTest/kotlin/fr/acinq/eclair/db/PaymentsDbTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/db/PaymentsDbTestsCommon.kt
@@ -189,11 +189,11 @@ class PaymentsDbTestsCommon : EclairTestSuite() {
 
         // Payment succeeds: failed parts will be ignored.
         val paymentSucceeded = partsSettled.copy(
-            status = OutgoingPayment.Status.Succeeded(preimage, 130),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(preimage, 130),
             parts = partsSettled.parts.drop(1)
         )
-        db.updateOutgoingPayment(initialPayment.id, preimage, 130)
-        assertFails { db.updateOutgoingPayment(UUID.randomUUID(), preimage, 130) }
+        db.completeOutgoingPayment(initialPayment.id, preimage, 130)
+        assertFails { db.completeOutgoingPayment(UUID.randomUUID(), preimage, 130) }
         assertEquals(paymentSucceeded, db.getOutgoingPayment(initialPayment.id))
         partsSettled.parts.forEach { assertEquals(paymentSucceeded, db.getOutgoingPart(it.id)) }
     }
@@ -227,9 +227,9 @@ class PaymentsDbTestsCommon : EclairTestSuite() {
         assertEquals(partsFailed, db.getOutgoingPayment(initialPayment.id))
         initialPayment.parts.forEach { assertEquals(partsFailed, db.getOutgoingPart(it.id)) }
 
-        val paymentFailed = partsFailed.copy(status = OutgoingPayment.Status.Failed(FinalFailure.NoRouteToRecipient, 120))
-        db.updateOutgoingPayment(initialPayment.id, FinalFailure.NoRouteToRecipient, 120)
-        assertFails { db.updateOutgoingPayment(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
+        val paymentFailed = partsFailed.copy(status = OutgoingPayment.Status.Completed.Failed(FinalFailure.NoRouteToRecipient, 120))
+        db.completeOutgoingPayment(initialPayment.id, FinalFailure.NoRouteToRecipient, 120)
+        assertFails { db.completeOutgoingPayment(UUID.randomUUID(), FinalFailure.NoRouteToRecipient, 120) }
         assertEquals(paymentFailed, db.getOutgoingPayment(initialPayment.id))
         initialPayment.parts.forEach { assertEquals(paymentFailed, db.getOutgoingPart(it.id)) }
     }
@@ -269,18 +269,18 @@ class PaymentsDbTestsCommon : EclairTestSuite() {
         // Pending payments should not be listed.
         assertTrue(db.listOutgoingPayments(count = 10, skip = 0).isEmpty())
 
-        db.updateOutgoingPayment(pending1.id, randomBytes32(), completedAt = 100)
+        db.completeOutgoingPayment(pending1.id, randomBytes32(), completedAt = 100)
         val payment1 = db.getOutgoingPayment(pending1.id)!!
-        db.updateOutgoingPayment(pending2.id, FinalFailure.NoRouteToRecipient, completedAt = 101)
+        db.completeOutgoingPayment(pending2.id, FinalFailure.NoRouteToRecipient, completedAt = 101)
         val payment2 = db.getOutgoingPayment(pending2.id)!!
         // payment3 is still pending
-        db.updateOutgoingPayment(pending4.id, FinalFailure.InsufficientBalance, completedAt = 102)
+        db.completeOutgoingPayment(pending4.id, FinalFailure.InsufficientBalance, completedAt = 102)
         val payment4 = db.getOutgoingPayment(pending4.id)!!
-        db.updateOutgoingPayment(pending5.id, randomBytes32(), completedAt = 103)
+        db.completeOutgoingPayment(pending5.id, randomBytes32(), completedAt = 103)
         val payment5 = db.getOutgoingPayment(pending5.id)!!
-        db.updateOutgoingPayment(pending6.id, randomBytes32(), completedAt = 104)
+        db.completeOutgoingPayment(pending6.id, randomBytes32(), completedAt = 104)
         val payment6 = db.getOutgoingPayment(pending6.id)!!
-        db.updateOutgoingPayment(pending7.id, randomBytes32(), completedAt = 105)
+        db.completeOutgoingPayment(pending7.id, randomBytes32(), completedAt = 105)
         val payment7 = db.getOutgoingPayment(pending7.id)!!
 
         assertEquals(listOf(payment7, payment6, payment5, payment4, payment2, payment1), db.listOutgoingPayments(count = 10, skip = 0))
@@ -314,17 +314,17 @@ class PaymentsDbTestsCommon : EclairTestSuite() {
 
         db.receivePayment(incoming1.paymentHash, 20_000.msat, IncomingPayment.ReceivedWith.LightningPayment, receivedAt = 100)
         val inFinal1 = incoming1.copy(received = IncomingPayment.Received(20_000.msat, IncomingPayment.ReceivedWith.LightningPayment, 100))
-        db.updateOutgoingPayment(outgoing1.id, randomBytes32(), completedAt = 102)
+        db.completeOutgoingPayment(outgoing1.id, randomBytes32(), completedAt = 102)
         val outFinal1 = db.getOutgoingPayment(outgoing1.id)!!
-        db.updateOutgoingPayment(outgoing2.id, FinalFailure.UnknownError, completedAt = 103)
+        db.completeOutgoingPayment(outgoing2.id, FinalFailure.UnknownError, completedAt = 103)
         val outFinal2 = db.getOutgoingPayment(outgoing2.id)!!
         db.receivePayment(incoming2.paymentHash, 25_000.msat, IncomingPayment.ReceivedWith.NewChannel(250.msat, channelId = null), receivedAt = 105)
         val inFinal2 = incoming2.copy(received = IncomingPayment.Received(25_000.msat, IncomingPayment.ReceivedWith.NewChannel(250.msat, channelId = null), 105))
-        db.updateOutgoingPayment(outgoing3.id, randomBytes32(), completedAt = 106)
+        db.completeOutgoingPayment(outgoing3.id, randomBytes32(), completedAt = 106)
         val outFinal3 = db.getOutgoingPayment(outgoing3.id)!!
         db.receivePayment(incoming4.paymentHash, 10_000.msat, IncomingPayment.ReceivedWith.LightningPayment, receivedAt = 110)
         val inFinal4 = incoming4.copy(received = IncomingPayment.Received(10_000.msat, IncomingPayment.ReceivedWith.LightningPayment, 110))
-        db.updateOutgoingPayment(outgoing5.id, randomBytes32(), completedAt = 112)
+        db.completeOutgoingPayment(outgoing5.id, randomBytes32(), completedAt = 112)
         val outFinal5 = db.getOutgoingPayment(outgoing5.id)!!
         // outgoing4 and incoming3 are still pending.
 

--- a/src/commonTest/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandlerTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/payment/OutgoingPaymentHandlerTestsCommon.kt
@@ -55,8 +55,8 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertNotNull(dbPayment)
         assertEquals(100_000.msat, dbPayment.recipientAmount)
         assertEquals(invoice.nodeId, dbPayment.recipient)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Failed)
-        assertEquals(FinalFailure.NoAvailableChannels, (dbPayment.status as OutgoingPayment.Status.Failed).reason)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
+        assertEquals(FinalFailure.NoAvailableChannels, (dbPayment.status as OutgoingPayment.Status.Completed.Failed).reason)
         assertTrue(dbPayment.parts.isEmpty())
     }
 
@@ -74,8 +74,8 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         val dbPayment = outgoingPaymentHandler.db.getOutgoingPayment(payment.paymentId)
         assertNotNull(dbPayment)
         assertEquals(amount, dbPayment.recipientAmount)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Failed)
-        assertEquals(FinalFailure.InsufficientBalance, (dbPayment.status as OutgoingPayment.Status.Failed).reason)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
+        assertEquals(FinalFailure.InsufficientBalance, (dbPayment.status as OutgoingPayment.Status.Completed.Failed).reason)
         assertTrue(dbPayment.parts.isEmpty())
     }
 
@@ -230,7 +230,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success.payment.recipient)
         assertEquals(invoice.paymentHash, success.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success.payment.details)
-        assertEquals(preimage, (success.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(1, success.payment.parts.size)
         val part = success.payment.parts.first()
         assertNotEquals(part.id, payment.paymentId)
@@ -292,7 +292,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(310_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -344,7 +344,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(310_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -399,7 +399,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(TestConstants.Bob.nodeParams.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(300_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -470,7 +470,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(invoice.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(301_030.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -478,7 +478,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertNull(outgoingPaymentHandler.getPendingPayment(payment.paymentId))
         val dbPayment2 = outgoingPaymentHandler.db.getOutgoingPayment(payment.paymentId)
         assertNotNull(dbPayment2)
-        assertTrue(dbPayment2.status is OutgoingPayment.Status.Succeeded)
+        assertTrue(dbPayment2.status is OutgoingPayment.Status.Completed.Succeeded.OffChain)
         assertEquals(2, dbPayment2.parts.size)
         assertTrue(dbPayment2.parts.all { it.status is OutgoingPayment.Part.Status.Succeeded })
     }
@@ -516,7 +516,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertEquals(TestConstants.Bob.nodeParams.nodeId, success2.payment.recipient)
         assertEquals(invoice.paymentHash, success2.payment.paymentHash)
         assertEquals(OutgoingPayment.Details.Normal(invoice), success2.payment.details)
-        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+        assertEquals(preimage, (success2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         assertEquals(2, success2.payment.parts.size)
         assertEquals(300_000.msat, success2.payment.parts.map { it.amount }.sum())
         assertEquals(setOf(preimage), success2.payment.parts.map { (it.status as OutgoingPayment.Part.Status.Succeeded).preimage }.toSet())
@@ -804,7 +804,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
             assertEquals(preimage, result2.preimage)
             assertEquals(3, result2.payment.parts.size)
             assertEquals(payment, SendPayment(result2.payment.id, result2.payment.recipientAmount, result2.payment.recipient, result2.payment.details as OutgoingPayment.Details.Normal))
-            assertEquals(preimage, (result2.payment.status as OutgoingPayment.Status.Succeeded).preimage)
+            assertEquals(preimage, (result2.payment.status as OutgoingPayment.Status.Completed.Succeeded.OffChain).preimage)
         }
     }
 
@@ -889,7 +889,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
     private suspend fun assertDbPaymentFailed(db: OutgoingPaymentsDb, paymentId: UUID, partsCount: Int) {
         val dbPayment = db.getOutgoingPayment(paymentId)
         assertNotNull(dbPayment)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Failed)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Failed)
         assertEquals(partsCount, dbPayment.parts.size)
         assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Failed })
     }
@@ -899,7 +899,7 @@ class OutgoingPaymentHandlerTestsCommon : EclairTestSuite() {
         assertNotNull(dbPayment)
         assertEquals(amount, dbPayment.recipientAmount)
         assertEquals(fees, dbPayment.fees)
-        assertTrue(dbPayment.status is OutgoingPayment.Status.Succeeded)
+        assertTrue(dbPayment.status is OutgoingPayment.Status.Completed.Succeeded.OffChain)
         assertEquals(partsCount, dbPayment.parts.size)
         assertTrue(dbPayment.parts.all { it.status is OutgoingPayment.Part.Status.Succeeded })
     }


### PR DESCRIPTION
Phoenix-kmm [issue #123](https://github.com/ACINQ/phoenix-kmm/issues/123):

> When the user chooses to close (or force-close) a channel, there should be a corresponding transaction. From the user's perspective, any operation that alters the ledger should have a corresponding transaction.

Logic overview:

- When a channel transitions to `Closing`, and the channel has a non-zero balance, we inject an OutgoingTransaction into the ledger. The transaction is marked as `Pending`
- When the corresponding channel transitions to `Closed`, we mark the OutgoingTransaction as `Completed.Succeeded.OnChain`, and we record the corresponding txid's & fees.



In terms of code changes, we needed to add a new class to `OutgoingPayment.Details`:

```kotlin
data class ChannelClosing(
   val closingAddress: String,
   val isLocalWallet: Boolean, /*...*/
) : Details()
```



And we refactored `OutgoingPayment.Status` to include support for on-chain payments:

```kotlin
sealed class Status {
   object Pending : Status()
   sealed class Completed : Status() {
      abstract val completedAt: Long
      data class Failed(/*...*/) : Completed()
      sealed class Succeeded : Completed() {
         data class OffChain(/*...*/) : Completed()
         data class OnChain(
            val txids: List<ByteVector32>,
            val claimed: Satoshi,
            override val completedAt: Long
         ) : Completed()
      }
   }
}
```



Here's the code that runs when a channel transitions to the `Closing` state:

<details>
<summary>Code changes in Channel.kt</summary><p>

```kotlin
this is ChannelStateWithCommitments && newState is Closing -> {
   val channelBalance = commitments.localCommit.spec.toLocal
   if (channelBalance > 0.msat) {
      val defaultScriptPubKey = commitments.localParams.defaultFinalScriptPubKey
      val localShutdown = when (this) {
         is Normal -> this.localShutdown
         is Negotiating -> this.localShutdown
         is ShuttingDown -> this.localShutdown
         else -> null
      }
      if (localShutdown != null && localShutdown.scriptPubKey != defaultScriptPubKey) {
         // Non-default output address
         val btcAddr = Helpers.Closing.btcAddressFromScriptPubKey(
            scriptPubKey = localShutdown.scriptPubKey,
            chainHash = staticParams.nodeParams.chainHash
         ) ?: "unknown"
         actions + ChannelAction.Storage.StoreChannelClosing(
            amount = channelBalance,
            closingAddress = btcAddr,
            isLocalWallet = false
         )
      } else {
         // Default output address
         val btcAddr = Helpers.Closing.btcAddressFromScriptPubKey(
            scriptPubKey = defaultScriptPubKey,
            chainHash = staticParams.nodeParams.chainHash
         ) ?: "unknown"
         actions + ChannelAction.Storage.StoreChannelClosing(
            amount = channelBalance,
            closingAddress = btcAddr,
            isLocalWallet = true
         )
      }
   } else /* channelBalance <= 0.msat */ {
      actions
   }
}
```

</p></details>

From the user's perspective:

- they had a balance of X on the channel
- the channel was closed (one way or another)
- they see an OutgoingTransaction with amount -X
- this balances the ledger

Of course, the user may not actually receive X on-chain:

- pending HTLC's could go either direction
- millisatoshi's get truncated
- dust gets ignored

I'm taking a simplistic approach right now, and simply recording all on-chain amounts that we successfully "claimed". Any difference between the original amount and the claimed amount is regarded as "fees".

<details>
<summary>Code changes in Channel.kt</summary><p>

```kotlin
private fun completeChannelClosing(additionalConfirmedTx: Transaction?): ChannelAction.Storage.CompleteChannelClosing {
   // We want to give the user the list of btc transactions for their outputs
   val txids = mutableListOf<ByteVector32>()
   var claimed = 0.sat
   additionalConfirmedTx?.let { confirmedTx ->
      mutualClosePublished.firstOrNull { it == confirmedTx }?.let {
         txids += it.txid
         // NB: this code could be much simpler if we knew the localScriptPubKey
         var expectedAmount = commitments.localCommit.spec.toLocal.truncateToSatoshi()
         if (commitments.localParams.isFunder) {
            // we had to pay the closingFees
            val inputAmount = commitments.commitInput.txOut.amount
            val outputAmount = it.txOut.map { it.amount }.sum()
            val feesAmount = outputAmount - inputAmount
            expectedAmount -= feesAmount
         }
         claimed += expectedAmount
      }
   }
   localCommitPublished?.let {
      val confirmedTxids = it.irrevocablySpent.values.toSet()
      val allTxs = listOfNotNull(it.commitTx, it.claimMainDelayedOutputTx) + it.htlcSuccessTxs + it.htlcTimeoutTxs
      val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
      txids += confirmedTxs.map { it.txid }
      claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
   }
   listOfNotNull(
      remoteCommitPublished,
      nextRemoteCommitPublished,
      futureRemoteCommitPublished
   ).forEach {
      val confirmedTxids = it.irrevocablySpent.values.toSet()
      val allTxs = listOfNotNull(it.commitTx, it.claimMainOutputTx) + it.claimHtlcSuccessTxs + it.claimHtlcTimeoutTxs
      val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
      txids += confirmedTxs.map { it.txid }
      claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
   }
   revokedCommitPublished.forEach {
      val confirmedTxids = it.irrevocablySpent.values.toSet()
      val allTxs = listOfNotNull(it.commitTx, it.claimMainOutputTx, it.mainPenaltyTx) + it.htlcPenaltyTxs + it.claimHtlcDelayedPenaltyTxs
      val confirmedTxs = allTxs.filter { confirmedTxids.contains(it.txid) }
      txids += confirmedTxs.map { it.txid }
      claimed += confirmedTxs.map { it.txOut.map { it.amount }.sum() }.sum()
   }
   return ChannelAction.Storage.CompleteChannelClosing(txids, claimed)
}
```

</p></details>
