### PR TITLE
Make ChannelClosingType serializable

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/channel/Channel.kt
@@ -16,7 +16,7 @@ import fr.acinq.eclair.channel.Helpers.Closing.overriddenOutgoingHtlcs
 import fr.acinq.eclair.channel.Helpers.Closing.timedOutHtlcs
 import fr.acinq.eclair.crypto.KeyManager
 import fr.acinq.eclair.crypto.ShaChain
-import fr.acinq.eclair.db.OutgoingPayment.Status.Completed.Succeeded.OnChain.ChannelClosingType
+import fr.acinq.eclair.db.ChannelClosingType
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.serialization.Serialization
 import fr.acinq.eclair.transactions.CommitmentSpec
@@ -97,7 +97,7 @@ sealed class ChannelAction {
         data class GetHtlcInfos(val revokedCommitTxId: ByteVector32, val commitmentNumber: Long) : Storage()
         data class StoreIncomingAmount(val amount: MilliSatoshi, val origin: ChannelOrigin?) : Storage()
         data class StoreChannelClosing(val amount: MilliSatoshi, val closingAddress: String, val isSentToDefaultAddress: Boolean) : Storage()
-        data class StoreChannelClosed(val txids: List<ByteVector32>, val claimed: Satoshi, val type: ChannelClosingType) : Storage()
+        data class StoreChannelClosed(val txids: List<ByteVector32>, val claimed: Satoshi, val closingType: ChannelClosingType) : Storage()
     }
 
     data class ProcessIncomingHtlc(val add: UpdateAddHtlc) : ChannelAction()

--- a/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/db/PaymentsDb.kt
@@ -11,6 +11,7 @@ import fr.acinq.eclair.payment.FinalFailure
 import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.utils.*
 import fr.acinq.eclair.wire.FailureMessage
+import kotlinx.serialization.Serializable
 
 interface PaymentsDb : IncomingPaymentsDb, OutgoingPaymentsDb {
     /** List sent and received payments (with most recent payments first). */
@@ -226,13 +227,9 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
                     // In the future, we plan on storing the closing btc transactions as parts.
                     // Then we can use those parts to calculate the fees, and provide more details to the user.
                     val claimed: Satoshi,
-                    val type: ChannelClosingType,
+                    val closingType: ChannelClosingType,
                     override val completedAt: Long = currentTimestampMillis()
-                ) : Succeeded() {
-                    enum class ChannelClosingType {
-                        Mutual, Local, Remote, Revoked, Other
-                    }
-                }
+                ) : Succeeded()
             }
         }
     }
@@ -260,6 +257,11 @@ data class OutgoingPayment(val id: UUID, val recipientAmount: MilliSatoshi, val 
             }
         }
     }
+}
+
+@Serializable
+enum class ChannelClosingType {
+    Mutual, Local, Remote, Revoked, Other;
 }
 
 data class HopDesc(val nodeId: PublicKey, val nextNodeId: PublicKey, val shortChannelId: ShortChannelId? = null) {

--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -427,7 +427,7 @@ class Peer(
                 }
                 action is ChannelAction.Storage.StoreChannelClosed -> {
                     val dbId = UUID.fromBytes(channelId.take(16).toByteArray())
-                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed, action.type)
+                    val completed = OutgoingPayment.Status.Completed.Succeeded.OnChain(action.txids, action.claimed, action.closingType)
                     db.payments.completeOutgoingPayment(dbId, completed)
                     listenerEventChannel.send(ChannelClosing(channelId))
                 }

--- a/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/channel/states/ClosingTestsCommon.kt
@@ -20,7 +20,7 @@ import fr.acinq.eclair.channel.TestsHelper.mutualClose
 import fr.acinq.eclair.channel.TestsHelper.processEx
 import fr.acinq.eclair.channel.TestsHelper.reachNormal
 import fr.acinq.eclair.channel.TestsHelper.remoteClose
-import fr.acinq.eclair.db.OutgoingPayment.Status.Completed.Succeeded.OnChain.ChannelClosingType
+import fr.acinq.eclair.db.ChannelClosingType
 import fr.acinq.eclair.tests.TestConstants
 import fr.acinq.eclair.tests.utils.EclairTestSuite
 import fr.acinq.eclair.transactions.Scripts
@@ -111,7 +111,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         assertTrue { alice6 is Closed }
         val storeChannelClosed = aliceActions6.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.type == ChannelClosingType.Mutual }
+        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Mutual }
         assertTrue { storeChannelClosed.txids == listOf(mutualCloseTx.tx.txid) }
     }
 
@@ -125,7 +125,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         assertTrue { alice1 is Closed }
         val storeChannelClosed = actions1.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.type == ChannelClosingType.Mutual }
+        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Mutual }
         assertTrue { storeChannelClosed.txids == listOf(mutualCloseTx.tx.txid) }
     }
 
@@ -222,7 +222,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         )
         val storeChannelClosed = actions.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.type == ChannelClosingType.Local }
+        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Local }
         assertTrue {
             storeChannelClosed.txids.toSet() ==
             listOfNotNull(
@@ -564,7 +564,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         assertTrue(actions.contains(ChannelAction.Storage.StoreState(aliceClosed)))
         val storeChannelClosed = actions.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.type == ChannelClosingType.Remote }
+        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Remote }
         assertTrue {
             storeChannelClosed.txids.toSet() ==
             listOfNotNull(
@@ -1142,7 +1142,7 @@ class ClosingTestsCommon : EclairTestSuite() {
         )
         val storeChannelClosed = aliceActions5.filterIsInstance<ChannelAction.Storage.StoreChannelClosed>().firstOrNull()
         assertNotNull(storeChannelClosed)
-        assertTrue { storeChannelClosed.type == ChannelClosingType.Remote }
+        assertTrue { storeChannelClosed.closingType == ChannelClosingType.Remote }
         assertTrue { storeChannelClosed.txids.toSet() == aliceTxs.map { it.txid }.toSet() }
     }
 


### PR DESCRIPTION
This PR makes the channel closing type enum explicitly serializable. 

This should not be needed. However on Phoenix, this object is serialized and saved to DB. And when building the app on Mac,  kotlinx.serialization raises a compilation error (`AssertionError: Enum class does not have .values() function`). This does not happen on Android. Adding the annotation fixes the kotlinx.serialization compilation issue.

This commit also sanitizes the `ChannelClosingType` hierarchy which was a bit long.
