### PR TITLE
Do not override amount in db for incoming amount of pay-to-open origin

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/payment/IncomingPaymentHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/payment/IncomingPaymentHandler.kt
@@ -94,6 +94,54 @@ class IncomingPaymentHandler(val nodeParams: NodeParams, val walletParams: Walle
     }
 
     /**
+     * Save the "received-with" details of an incoming amount.
+     *
+     * - for a pay-to-open origin, we only save the id of the channel that was created for this payment.
+     * - for a swap-in origin, a new incoming payment must be created. We use the channel id to generate the payment's preimage.
+     * - for unknown origin, the amount is handled as a swap-in coming from an unknown address.
+     */
+    suspend fun process(channelId: ByteVector32, action: ChannelAction.Storage.StoreIncomingAmount) {
+        when (action.origin) {
+            null -> {
+                logger.warning { "incoming amount with empty origin, we store only minimal information" }
+                val fakePreimage = channelId.sha256()
+                db.addAndReceivePayment(
+                    preimage = fakePreimage,
+                    origin = IncomingPayment.Origin.SwapIn(address = ""),
+                    amount = action.amount,
+                    receivedWith = IncomingPayment.ReceivedWith.NewChannel(fees = 0.msat, channelId = channelId)
+                )
+            }
+            is ChannelOrigin.PayToOpenOrigin -> {
+                if (db.getIncomingPayment(action.origin.paymentHash) != null) {
+                    db.receivePayment(
+                        paymentHash = action.origin.paymentHash,
+                        amount = 0.msat, // do not update the amount, it's already set by the main payment handler.
+                        receivedWith = IncomingPayment.ReceivedWith.NewChannel(
+                            fees = action.origin.fee.toMilliSatoshi(),
+                            channelId = channelId
+                        )
+                    )
+                } else {
+                    logger.warning { "c:$channelId ignored pay-to-open origin action, there are no payments in db for payment_hash=${action.origin.paymentHash}" }
+                }
+            }
+            is ChannelOrigin.SwapInOrigin -> {
+                val fakePreimage = channelId.sha256()
+                db.addAndReceivePayment(
+                    preimage = fakePreimage,
+                    origin = IncomingPayment.Origin.SwapIn(address = action.origin.bitcoinAddress),
+                    amount = action.amount,
+                    receivedWith = IncomingPayment.ReceivedWith.NewChannel(
+                        fees = action.origin.fee.toMilliSatoshi(),
+                        channelId = channelId
+                    )
+                )
+            }
+        }
+    }
+
+    /**
      * Process an incoming htlc.
      * Before calling this, the htlc must be committed and ack-ed by both sides.
      *


### PR DESCRIPTION
This PR changes how the `StoreIncomingAmount` action is handled when the origin is `ChannelOrigin.PayToOpenOrigin`. The action's amount is now ignored, and only the payment's received-with field is updated.

### The issue

For pay-to-open (a channel is created but the origin is a LN invoice), a payment line has already been added and received in the database. That part is done by the `IncomingPaymentHandler` main processing method : https://github.com/ACINQ/eclair-kmp/blob/7d29237a54258cd67b1a32bcaf9599d6b66931ec/src/commonMain/kotlin/fr/acinq/eclair/payment/IncomingPaymentHandler.kt#L212-L219

However, the `db.receiveIncomingPayment` method will **ADD** the given amount to the already received amount for this payment.

The reason why is that we may receive several payments for a given payment hash, and as such `db.receiveIncomingPayment` must be additive. For reference, see this issue on phoenix: https://github.com/ACINQ/phoenix-kmm/issues/100

So saving the `StoreIncomingAmount` action amount causes the amount to be incorrect (actually doubled) in the database.

### Proposed solution

The proposed solution is to save a 0.msat amount for `StoreIncomingAmount` where origin is `PayToOpenOrigin`.

This PR also add some tests and fixes the `InMemoryDb.receiveIncomingPayment` method.