### PR TITLE
Add chain hash to serialised channel data

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/serialization/v1/ChannelState.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/serialization/v1/ChannelState.kt
@@ -318,10 +318,13 @@ data class OnChainFeerates(val mutualCloseFeerate: FeeratePerKw, val claimMainFe
 }
 
 @Serializable
-data class StaticParams(@Serializable(with = PublicKeyKSerializer::class) val remoteNodeId: PublicKey) {
-    constructor(from: fr.acinq.eclair.channel.StaticParams) : this(from.remoteNodeId)
+data class StaticParams(@Serializable(with = ByteVector32KSerializer::class) val chainHash: ByteVector32, @Serializable(with = PublicKeyKSerializer::class) val remoteNodeId: PublicKey) {
+    constructor(from: fr.acinq.eclair.channel.StaticParams) : this(from.nodeParams.chainHash, from.remoteNodeId)
 
-    fun export(nodeParams: NodeParams) = fr.acinq.eclair.channel.StaticParams(nodeParams, this.remoteNodeId)
+    fun export(nodeParams: NodeParams): fr.acinq.eclair.channel.StaticParams {
+        require(chainHash == nodeParams.chainHash) { "restoring data from a different chain" }
+        return fr.acinq.eclair.channel.StaticParams(nodeParams, this.remoteNodeId)
+    }
 }
 
 @Serializable

--- a/src/commonTest/kotlin/fr/acinq/eclair/serialization/StateSerializationTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/serialization/StateSerializationTestsCommon.kt
@@ -1,11 +1,11 @@
 package fr.acinq.eclair.serialization
 
+import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.Eclair.randomKey
 import fr.acinq.eclair.channel.TestsHelper
 import fr.acinq.eclair.tests.utils.EclairTestSuite
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 @OptIn(ExperimentalSerializationApi::class)
 class StateSerializationTestsCommon : EclairTestSuite() {
@@ -33,5 +33,19 @@ class StateSerializationTestsCommon : EclairTestSuite() {
         val bytes1 = Serialization.encrypt(priv, bob)
         val check1 = Serialization.decrypt(priv, bytes1, bob.staticParams.nodeParams)
         assertEquals(bob, check1)
+    }
+
+    @Test
+    fun `don't restore data from a different chain`() {
+        val (alice, _) = TestsHelper.reachNormal()
+        val priv = randomKey()
+        val bytes = Serialization.encrypt(priv, alice)
+        val check = Serialization.decrypt(priv, bytes, alice.staticParams.nodeParams)
+        assertEquals(alice, check)
+
+        val error = assertFails {
+            Serialization.decrypt(priv, bytes, alice.staticParams.nodeParams.copy(chainHash = Block.LivenetGenesisBlock.hash))
+        }
+        assertTrue(error.message!!.contains("restoring data from a different chain"))
     }
 }


### PR DESCRIPTION
This will prevent users from restoring channels created on a different chain.