### PR TITLE
Fixing bitcode compilation issues

### DIFF
--- a/PhoenixCrypto/build.gradle.kts
+++ b/PhoenixCrypto/build.gradle.kts
@@ -6,7 +6,8 @@ listOf("iphoneos", "iphonesimulator").forEach { sdk ->
             "xcodebuild",
             "-project", "PhoenixCrypto.xcodeproj",
             "-target", "PhoenixCrypto",
-            "-sdk", sdk
+            "-sdk", sdk,
+            "BITCODE_GENERATION_MODE=bitcode"
         )
         workingDir(projectDir)
 


### PR DESCRIPTION
We recently ran into compilation issues when attempting to build a version of the app for the App Store. (Xcode > Product > Archive) The error message is:

> Bitcode bundle could not be generated because 'PhoenixShared' was built without full bitcode.

The problem was that the native iOS crypto module was being compiled without [bitcode](https://thenextweb.com/apple/2015/06/17/apples-biggest-developer-news-at-wwdc-that-nobodys-talking-about-bitcode/) support enabled. Since bitcode is all-or-nothing, this meant that any apps linking with it would be ineligible for bitcode-enabled uploads to the App Store.