### PR TITLE
Invoice expiry can now be modified

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
+++ b/src/commonMain/kotlin/fr/acinq/eclair/io/Peer.kt
@@ -41,7 +41,7 @@ data class WrappedChannelEvent(val channelId: ByteVector32, val channelEvent: Ch
 object Disconnected : PeerEvent()
 
 sealed class PaymentEvent : PeerEvent()
-data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val result: CompletableDeferred<PaymentRequest>) : PaymentEvent()
+data class ReceivePayment(val paymentPreimage: ByteVector32, val amount: MilliSatoshi?, val description: String, val expirySeconds: Long? = null, val result: CompletableDeferred<PaymentRequest>) : PaymentEvent()
 object CheckPaymentsTimeout : PaymentEvent()
 data class PayToOpenResponseEvent(val payToOpenResponse: PayToOpenResponse) : PeerEvent()
 data class SendPayment(val paymentId: UUID, val amount: MilliSatoshi, val recipient: PublicKey, val details: OutgoingPayment.Details.Normal) : PaymentEvent() {
@@ -669,7 +669,7 @@ class Peer(
                         )
                     )
                 )
-                val pr = incomingPaymentHandler.createInvoice(event.paymentPreimage, event.amount, event.description, extraHops)
+                val pr = incomingPaymentHandler.createInvoice(event.paymentPreimage, event.amount, event.description, extraHops, event.expirySeconds)
                 listenerEventChannel.send(PaymentRequestGenerated(event, pr.write()))
                 event.result.complete(pr)
             }

--- a/src/commonTest/kotlin/fr/acinq/eclair/io/peer/PeerTest.kt
+++ b/src/commonTest/kotlin/fr/acinq/eclair/io/peer/PeerTest.kt
@@ -178,7 +178,6 @@ class PeerTest : EclairTestSuite() {
             val deferredInvoice = CompletableDeferred<PaymentRequest>()
             bob.send(ReceivePayment(randomBytes32(), 1.msat, "A description: \uD83D\uDE2C", 3600 * 3, deferredInvoice))
             val invoice = deferredInvoice.await()
-            // The routing hint uses default values since no channel update has been sent by Alice yet.
             assertEquals(1.msat, invoice.amount)
             assertEquals(3600 * 3, invoice.expirySeconds)
             assertEquals("A description: \uD83D\uDE2C", invoice.description)

--- a/src/jvmTest/kotlin/fr/acinq/eclair/Node.kt
+++ b/src/jvmTest/kotlin/fr/acinq/eclair/Node.kt
@@ -233,7 +233,7 @@ object Node {
                         val paymentPreimage = Eclair.randomBytes32()
                         val amount = MilliSatoshi(request.amount ?: 50000L)
                         val result = CompletableDeferred<PaymentRequest>()
-                        peer.send(ReceivePayment(paymentPreimage, amount, request.description.orEmpty(), result))
+                        peer.send(ReceivePayment(paymentPreimage, amount, request.description.orEmpty(), null, result))
                         call.respond(CreateInvoiceResponse(result.await().write()))
                     }
                     post("/invoice/pay") {


### PR DESCRIPTION
The `ReceivePayment` event now accepts a nullable expiry that will be used when generating an invoice. This will allow Phoenix to set a custom expiry (1 week by default).

A test has also been added.